### PR TITLE
refactor: improve tagging to include indices

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,31 @@
 
 Kotlin implementation of the [OCI Distribution client specification](https://github.com/opencontainers/distribution-spec/blob/master/spec.md).
 
+## Basic Usage
+
+```kotlin
+// 0. Create a file store
+val store = runBlocking { Layout.create("/tmp/koci-store") }.getOrThrow()
+
+// 1. Connect to a remote repository
+
+// Note: the below code can be omitted if authentication is not required
+val authClient = HttpClient(CIO) {
+    install(OCIAuthPlugin) {
+        cred = Credential("username", "password", "", "")   
+    }
+}
+
+val repo = Registry("https://myregistry.example.com", authClient).repo("myrepo")
+
+// 2. Copy from the remote repository to the file store
+val tag = "latest"
+
+repo.pull(tag, null, store).collect{ prog ->
+    println("$prog% done")
+}
+```
+
 ## Auth
 
 - [x] [Request scopes](https://distribution.github.io/distribution/spec/auth/scope/) https://github.com/distribution/distribution/blob/v2.7.1/registry/handlers/app.go#L921-L930

--- a/src/main/kotlin/com/defenseunicorns/koci/DataClasses.kt
+++ b/src/main/kotlin/com/defenseunicorns/koci/DataClasses.kt
@@ -22,11 +22,7 @@ data class Manifest(
     val config: Descriptor,
     val layers: List<Descriptor>,
     val annotations: Annotations? = null,
-) : TaggableContent {
-    fun sizeOfLayers(): Long {
-        return layers.sumOf { it.size }
-    }
-}
+) : TaggableContent
 
 object CopyOnWriteDescriptorArrayListSerializer : KSerializer<CopyOnWriteArrayList<Descriptor>> {
     override val descriptor: SerialDescriptor = ListSerializer(Descriptor.serializer()).descriptor

--- a/src/main/kotlin/com/defenseunicorns/koci/Errors.kt
+++ b/src/main/kotlin/com/defenseunicorns/koci/Errors.kt
@@ -73,6 +73,9 @@ sealed class OCIException(message: String) : Exception(message) {
 
     class EmptyTokenReturned(val response: HttpResponse) :
         OCIException("${response.call.request.method} ${response.call.request.url}: empty token returned")
+
+    class UnableToRemove(val descriptor: Descriptor, val reason: String) :
+            OCIException("Unable to remove $descriptor: $reason")
 }
 
 /**

--- a/src/main/kotlin/com/defenseunicorns/koci/Layout.kt
+++ b/src/main/kotlin/com/defenseunicorns/koci/Layout.kt
@@ -291,8 +291,8 @@ class Layout private constructor(
     suspend fun tag(descriptor: Descriptor, reference: Reference) = runCatching {
         require(descriptor.mediaType.isNotEmpty())
         require(
-            descriptor.mediaType == MANIFEST_MEDIA_TYPE.toString()
-                    || descriptor.mediaType == INDEX_MEDIA_TYPE.toString()
+            descriptor.mediaType == MANIFEST_MEDIA_TYPE
+                    || descriptor.mediaType == INDEX_MEDIA_TYPE
         )
         require(descriptor.size > 0)
 

--- a/src/main/kotlin/com/defenseunicorns/koci/Layout.kt
+++ b/src/main/kotlin/com/defenseunicorns/koci/Layout.kt
@@ -97,6 +97,7 @@ class Layout private constructor(
 
     // TODO: ensure removals do not impact other images through unit tests
     @OptIn(ExperimentalSerializationApi::class)
+    @Suppress("detekt:LongMethod", "detekt:CyclomaticComplexMethod")
     override suspend fun remove(descriptor: Descriptor): Result<Boolean> = runCatching {
         val file = blob(descriptor)
 
@@ -140,7 +141,7 @@ class Layout private constructor(
                             val i: Index = fetch(desc).use { Json.decodeFromStream(it) }
                             i.manifests + i.manifests.flatMap { manifestDesc ->
                                 // manifest could have been removed in a previous loop
-                                if (blob(manifestDesc).exists()) {
+                                if (withContext(Dispatchers.IO) { blob(manifestDesc).exists() }) {
                                     fetch(manifestDesc).use {
                                         val m = Json.decodeFromStream<Manifest>(it)
                                         m.layers + m.config

--- a/src/main/kotlin/com/defenseunicorns/koci/Registry.kt
+++ b/src/main/kotlin/com/defenseunicorns/koci/Registry.kt
@@ -206,12 +206,13 @@ class Registry(
 
 fun Registry.repo(name: String) = Repository(client, router, name)
 suspend fun Registry.tags(repository: String) = repo(repository).tags()
-suspend fun Registry.resolve(repository: String, tag: String) =
-    repo(repository).resolve(tag)
+suspend fun Registry.resolve(repository: String, tag: String, platformResolver: ((Platform) -> Boolean)? = null) =
+    repo(repository).resolve(tag, platformResolver)
 
 fun Registry.pull(
     repository: String,
     tag: String,
+    platformResolver: ((Platform) -> Boolean)? = null,
     storage: Layout,
 ) =
-    repo(repository).pull(tag, storage)
+    repo(repository).pull(tag, platformResolver, storage)

--- a/src/main/kotlin/com/defenseunicorns/koci/Registry.kt
+++ b/src/main/kotlin/com/defenseunicorns/koci/Registry.kt
@@ -211,13 +211,12 @@ class Registry(
 
 fun Registry.repo(name: String) = Repository(client, router, name)
 suspend fun Registry.tags(repository: String) = repo(repository).tags()
-suspend fun Registry.resolve(repository: String, tag: String, resolver: (Platform) -> Boolean = ::defaultResolver) =
-    repo(repository).resolve(tag, resolver)
+suspend fun Registry.resolve(repository: String, tag: String) =
+    repo(repository).resolve(tag)
 
 fun Registry.pull(
     repository: String,
     tag: String,
     storage: Layout,
-    resolver: (Platform) -> Boolean = ::defaultResolver,
 ) =
-    repo(repository).pull(tag, storage, resolver)
+    repo(repository).pull(tag, storage)

--- a/src/main/kotlin/com/defenseunicorns/koci/Registry.kt
+++ b/src/main/kotlin/com/defenseunicorns/koci/Registry.kt
@@ -28,11 +28,6 @@ const val MANIFEST_MEDIA_TYPE = "application/vnd.oci.image.manifest.v1+json"
 const val MANIFEST_CONFIG_MEDIA_TYPE = "application/vnd.oci.image.config.v1+json"
 const val INDEX_MEDIA_TYPE = "application/vnd.oci.image.index.v1+json"
 
-/**
- * Zarf-specific "multi" OS
- */
-const val MULTI_OS = "multi"
-
 private fun URLBuilder.paginate(n: Int, last: String? = null): URLBuilder = apply {
     parameters.append("n", n.toString())
     last?.let { parameters.append("last", it) }

--- a/src/main/kotlin/com/defenseunicorns/koci/Repository.kt
+++ b/src/main/kotlin/com/defenseunicorns/koci/Repository.kt
@@ -212,13 +212,11 @@ class Repository(
                     }
                 }.flattenMerge(concurrency = 3) // TODO: figure out best API to expose concurrency settings
                     .onCompletion { cause ->
-                        // if there were no errors, then we can save the manifest itself and "mark" this pull as done
                         if (cause == null) {
                             copy(descriptor, store).collect { progress ->
                                 acc += progress
                                 emit((acc * 100 / total).roundToInt())
                             }
-                            store.exists(descriptor).getOrThrow()
                         }
                     }.collect { progress ->
                         send(progress)

--- a/src/test/kotlin/com/defenseunicorns/koci/RegistryTest.kt
+++ b/src/test/kotlin/com/defenseunicorns/koci/RegistryTest.kt
@@ -250,12 +250,6 @@ class RegistryTest {
         val index = registry.repo("dos-games").index(indexDesc).getOrThrow()
         val prog = registry.pull("dos-games", "1.1.0", null, storage)
 
-        val repo = registry.repo("dos-games")
-        repo.pull("tag", null, storage)
-        .collect{ prog ->
-            println("$prog% done")
-        }
-
         assertEquals(
             100, prog.last()
         )

--- a/src/test/kotlin/com/defenseunicorns/koci/RegistryTest.kt
+++ b/src/test/kotlin/com/defenseunicorns/koci/RegistryTest.kt
@@ -378,7 +378,7 @@ class RegistryTest {
         val dummy = "{}".byteInputStream()
 
         val dummyDesc = Descriptor.fromInputStream(
-            mediaType = MANIFEST_CONFIG_MEDIA_TYPE.toString(), stream = dummy
+            mediaType = MANIFEST_CONFIG_MEDIA_TYPE, stream = dummy
         )
 
         dummy.reset()
@@ -387,7 +387,7 @@ class RegistryTest {
         repo.push(dummy, dummyDesc).collect()
 
         val manifest = Manifest(
-            schemaVersion = 2, mediaType = MANIFEST_MEDIA_TYPE.toString(), config = dummyDesc, layers = listOf(desc)
+            schemaVersion = 2, mediaType = MANIFEST_MEDIA_TYPE, config = dummyDesc, layers = listOf(desc)
         )
 
         repo.tag(manifest, "latest").also { res ->

--- a/src/test/kotlin/com/defenseunicorns/koci/RegistryTest.kt
+++ b/src/test/kotlin/com/defenseunicorns/koci/RegistryTest.kt
@@ -116,7 +116,7 @@ class RegistryTest {
 
         val all = mutableListOf(
             TagsResponse("dos-games", listOf("1.1.0")),
-            TagsResponse("library/registry", listOf("2.8.0", "latest")),
+            TagsResponse("library/registry", listOf("latest", "2.8.0")),
             TagsResponse("test-upload", null),
         )
 

--- a/src/test/kotlin/com/defenseunicorns/koci/RegistryTest.kt
+++ b/src/test/kotlin/com/defenseunicorns/koci/RegistryTest.kt
@@ -49,6 +49,9 @@ class RegistryTest {
             install(UserAgent) {
                 agent = "unit test client"
             }
+            install(OCIAuthPlugin){
+                cred = Credential("username", "password", "", "")
+            }
         }
     }
 
@@ -246,6 +249,12 @@ class RegistryTest {
         val indexDesc = registry.resolve("dos-games", "1.1.0").getOrThrow()
         val index = registry.repo("dos-games").index(indexDesc).getOrThrow()
         val prog = registry.pull("dos-games", "1.1.0", null, storage)
+
+        val repo = registry.repo("dos-games")
+        repo.pull("tag", null, storage)
+        .collect{ prog ->
+            println("$prog% done")
+        }
 
         assertEquals(
             100, prog.last()

--- a/src/test/kotlin/com/defenseunicorns/koci/RegistryTest.kt
+++ b/src/test/kotlin/com/defenseunicorns/koci/RegistryTest.kt
@@ -53,12 +53,6 @@ class RegistryTest {
         Layout.create(tmp.toString())
     }.getOrThrow()
 
-    private val currentArch = if (System.getProperty("os.arch") == "aarch64") "arm64" else "amd64"
-
-    private fun zarfResolver(platform: Platform): Boolean {
-        return platform.architecture == currentArch && platform.os == MULTI_OS
-    }
-
     private val registry = Registry("http://127.0.0.1:5005", httpClient) // matches docker-compose.yaml
 
     @Test
@@ -122,7 +116,7 @@ class RegistryTest {
 
         val all = mutableListOf(
             TagsResponse("dos-games", listOf("1.1.0")),
-            TagsResponse("library/registry", listOf("latest", "2.8.0")),
+            TagsResponse("library/registry", listOf("2.8.0", "latest")),
             TagsResponse("test-upload", null),
         )
 
@@ -135,20 +129,19 @@ class RegistryTest {
 
     @Test
     fun resolve() = runTest {
-        val result = registry.repo("dos-games").resolve("1.1.0", ::zarfResolver)
+        val result = registry.repo("dos-games").resolve("1.1.0")
         assertTrue(result.isSuccess)
         val desc = result.getOrThrow()
         // TODO (razzle): bad litmus test, make better
-        assertEquals(desc.mediaType, MANIFEST_MEDIA_TYPE)
-        assertEquals(currentArch, desc.platform!!.architecture)
+        assertEquals(desc.mediaType, INDEX_MEDIA_TYPE)
     }
 
     @Test
     fun `fetch a layer`() = runTest {
         val repo = registry.repo("dos-games")
-        val desc = repo.resolve("1.1.0", ::zarfResolver).getOrThrow()
+        val desc = repo.resolve("1.1.0").getOrThrow()
 
-        val manifest = repo.manifest(desc).getOrThrow()
+        val manifest = repo.manifest(repo.index(desc).getOrThrow().manifests.first()).getOrThrow()
 
         val p = repo.pull(
             manifest.config, storage
@@ -200,8 +193,8 @@ class RegistryTest {
     @Test
     fun `fetch a layer, cancelling multiple times`() = runTest {
         val repo = registry.repo("dos-games")
-        val manifestDesc = repo.resolve("1.1.0", ::zarfResolver).getOrThrow()
-        val layer = repo.manifest(manifestDesc).getOrThrow().layers.maxBy { it.size }
+        val manifestDesc = repo.resolve("1.1.0").getOrThrow()
+        val layer = repo.manifest(repo.index(manifestDesc).getOrThrow().manifests.first()).getOrThrow().layers.maxBy { it.size }
 
         val cancelAtBytes = listOf(layer.size.toInt() / 4, layer.size.toInt() / 2, -100)
 
@@ -245,8 +238,8 @@ class RegistryTest {
 
     @Test
     fun `pull and remove dos-games`() = runTest {
-        val desc = registry.resolve("dos-games", "1.1.0", ::zarfResolver).getOrThrow()
-        val prog = registry.pull("dos-games", "1.1.0", storage, ::zarfResolver)
+        val desc = registry.resolve("dos-games", "1.1.0").getOrThrow()
+        val prog = registry.pull("dos-games", "1.1.0", storage)
 
         assertEquals(
             100, prog.last()
@@ -267,7 +260,7 @@ class RegistryTest {
         for (at in cancelAt) {
             launch {
                 var lastEmit = 0
-                registry.pull("dos-games", "1.1.0", storage, ::zarfResolver).onCompletion { e ->
+                registry.pull("dos-games", "1.1.0", storage).onCompletion { e ->
                     if (at == -100) {
                         assertNull(e)
                         assertEquals(
@@ -277,7 +270,7 @@ class RegistryTest {
                         assertIs<CancellationException>(e)
                         assertFailsWith<NoSuchElementException> {
                             val desc =
-                                runBlocking { registry.resolve("dos-games", "1.1.0", ::zarfResolver).getOrThrow() }
+                                runBlocking { registry.resolve("dos-games", "1.1.0").getOrThrow() }
                             storage.resolve {
                                 it.digest == desc.digest
                             }.getOrThrow()
@@ -285,11 +278,13 @@ class RegistryTest {
                     }
                 }.collect { progress ->
                     lastEmit = progress
-                    if (at == progress) cancel()
+                    if (at == progress){
+                        cancel()
+                    }
                 }
             }.join()
         }
-        val desc = registry.resolve("dos-games", "1.1.0", ::zarfResolver).getOrThrow()
+        val desc = registry.resolve("dos-games", "1.1.0").getOrThrow()
         // TODO: assert that removal of a artifact does not result in removal of any other artifact's dependent layers
         assertTrue(storage.remove(desc).getOrThrow())
     }
@@ -299,12 +294,10 @@ class RegistryTest {
         assertDoesNotThrow {
             runTest(timeout = kotlin.time.Duration.parse("PT2M")) {
                 val p1 = async {
-                    registry.pull("dos-games", "1.1.0", storage, ::zarfResolver).collect()
+                    registry.pull("dos-games", "1.1.0", storage).collect()
                 }
                 val p2 = async {
-                    registry.pull("library/registry", "latest", storage) { platform ->
-                        platform.os == "linux" && platform.architecture == currentArch
-                    }.collect()
+                    registry.pull("library/registry", "latest", storage).collect()
                 }
                 awaitAll(p1, p2)
             }
@@ -312,13 +305,11 @@ class RegistryTest {
 
         assertDoesNotThrow {
             runTest {
-                val d1 = registry.resolve("dos-games", "1.1.0", ::zarfResolver).getOrThrow()
+                val d1 = registry.resolve("dos-games", "1.1.0").getOrThrow()
                 val r1 = async {
                     storage.remove(d1).getOrThrow()
                 }
-                val d2 = registry.resolve("library/registry", "latest") { platform ->
-                    platform.os == "linux" && platform.architecture == currentArch
-                }.getOrThrow()
+                val d2 = registry.resolve("library/registry", "latest").getOrThrow()
                 val r2 = async {
                     storage.remove(d2).getOrThrow()
                 }

--- a/src/test/kotlin/com/defenseunicorns/koci/RegistryTest.kt
+++ b/src/test/kotlin/com/defenseunicorns/koci/RegistryTest.kt
@@ -49,9 +49,6 @@ class RegistryTest {
             install(UserAgent) {
                 agent = "unit test client"
             }
-            install(OCIAuthPlugin){
-                cred = Credential("username", "password", "", "")
-            }
         }
     }
 

--- a/src/test/kotlin/com/defenseunicorns/koci/RegistryTest.kt
+++ b/src/test/kotlin/com/defenseunicorns/koci/RegistryTest.kt
@@ -139,10 +139,9 @@ class RegistryTest {
     @Test
     fun `fetch a layer`() = runTest {
         val repo = registry.repo("dos-games")
-        val desc = repo.resolve("1.1.0").getOrThrow()
-
-        val manifest = repo.manifest(repo.index(desc).getOrThrow().manifests.first()).getOrThrow()
-
+        val manifest = repo.resolve("1.1.0")
+            .map { desc -> repo.index(desc).map { repo.manifest(it.manifests.first()).getOrThrow() }.getOrThrow() }
+            .getOrThrow()
         val p = repo.pull(
             manifest.config, storage
         )
@@ -193,9 +192,10 @@ class RegistryTest {
     @Test
     fun `fetch a layer, cancelling multiple times`() = runTest {
         val repo = registry.repo("dos-games")
-        val manifestDesc = repo.resolve("1.1.0").getOrThrow()
-        val layer =
-            repo.manifest(repo.index(manifestDesc).getOrThrow().manifests.first()).getOrThrow().layers.maxBy { it.size }
+        val desc = repo.resolve("1.1.0").getOrThrow()
+        val layer = repo.index(desc).map { index ->
+            repo.manifest(index.manifests.first()).getOrThrow().layers.maxBy { it.size }
+        }.getOrThrow()
 
         val cancelAtBytes = listOf(layer.size.toInt() / 4, layer.size.toInt() / 2, -100)
 

--- a/src/test/kotlin/com/defenseunicorns/koci/RegistryTest.kt
+++ b/src/test/kotlin/com/defenseunicorns/koci/RegistryTest.kt
@@ -253,7 +253,10 @@ class RegistryTest {
 
         val ref = Reference.parse("127.0.0.1:5005/dos-games:1.1.0").getOrThrow()
         assertEquals(indexDesc.digest, storage.resolve(ref).getOrThrow().digest)
-        assertEquals(listOf(indexDesc.copy(annotations = mapOf(ANNOTATION_REF_NAME to ref.toString()))), storage.catalog())
+        assertEquals(
+            listOf(indexDesc.copy(annotations = mapOf(ANNOTATION_REF_NAME to ref.toString()))),
+            storage.catalog()
+        )
 
         val arm64desc = index.manifests.first {
             it.platform?.architecture == "arm64"

--- a/src/test/kotlin/com/defenseunicorns/koci/RegistryTest.kt
+++ b/src/test/kotlin/com/defenseunicorns/koci/RegistryTest.kt
@@ -194,7 +194,8 @@ class RegistryTest {
     fun `fetch a layer, cancelling multiple times`() = runTest {
         val repo = registry.repo("dos-games")
         val manifestDesc = repo.resolve("1.1.0").getOrThrow()
-        val layer = repo.manifest(repo.index(manifestDesc).getOrThrow().manifests.first()).getOrThrow().layers.maxBy { it.size }
+        val layer =
+            repo.manifest(repo.index(manifestDesc).getOrThrow().manifests.first()).getOrThrow().layers.maxBy { it.size }
 
         val cancelAtBytes = listOf(layer.size.toInt() / 4, layer.size.toInt() / 2, -100)
 
@@ -278,7 +279,7 @@ class RegistryTest {
                     }
                 }.collect { progress ->
                     lastEmit = progress
-                    if (at == progress){
+                    if (at == progress) {
                         cancel()
                     }
                 }

--- a/src/test/kotlin/com/defenseunicorns/koci/RegistryTest.kt
+++ b/src/test/kotlin/com/defenseunicorns/koci/RegistryTest.kt
@@ -253,6 +253,7 @@ class RegistryTest {
 
         val ref = Reference.parse("127.0.0.1:5005/dos-games:1.1.0").getOrThrow()
         assertEquals(indexDesc.digest, storage.resolve(ref).getOrThrow().digest)
+        assertEquals(listOf(indexDesc.copy(annotations = mapOf(ANNOTATION_REF_NAME to ref.toString()))), storage.catalog())
 
         val arm64desc = index.manifests.first {
             it.platform?.architecture == "arm64"
@@ -260,6 +261,7 @@ class RegistryTest {
         val arm64Manifest: Manifest = storage.fetch(arm64desc).use { Json.decodeFromStream(it) }
         assertTrue(storage.remove(ref).getOrThrow())
         assertFails { storage.resolve(ref).getOrThrow() }
+        assertEquals(emptyList(), storage.catalog())
 
         for (layer in arm64Manifest.layers) {
             assertFalse {


### PR DESCRIPTION
Refactors tagging to include tagging indices and more proper management of manifests internally in `Layout`.  This collapses / addresses some additional edge cases around pulling, tagging, removing, and resolving OCI layers.
