### PR TITLE
test: increase coverage

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -11,6 +11,7 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+    types: [ milestoned, opened, edited, synchronize ]
   schedule:
     - cron: '41 1 * * 5'
 
@@ -50,7 +51,7 @@ jobs:
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     # Add any setup steps before running the `github/codeql-action/init` action.
     # This includes steps like installing compilers or runtimes (`actions/setup-node`
@@ -60,7 +61,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@b56ba49b26e50535fa1e7f7db0f4f7b4bf65d80d # v3.28.10
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
@@ -88,7 +89,7 @@ jobs:
         exit 1
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@b56ba49b26e50535fa1e7f7db0f4f7b4bf65d80d # v3.28.10
       with:
         category: "/language:${{matrix.language}}"
 

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -1,0 +1,94 @@
+# For most projects, this workflow file will not need changing; you simply need
+# to commit it to your repository.
+#
+# You may wish to alter this file to override the set of languages analyzed,
+# or to provide custom queries or build logic.
+#
+name: "CodeQL Advanced"
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  schedule:
+    - cron: '41 1 * * 5'
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    # Runner size impacts CodeQL analysis time. To learn more, please see:
+    #   - https://gh.io/recommended-hardware-resources-for-running-codeql
+    #   - https://gh.io/supported-runners-and-hardware-resources
+    #   - https://gh.io/using-larger-runners (GitHub.com only)
+    # Consider using larger runners or machines with greater resources for possible analysis time improvements.
+    runs-on: ubuntu-latest
+    permissions:
+      # required for all workflows
+      security-events: write
+
+      # required to fetch internal or private CodeQL packs
+      packages: read
+
+      # only required for workflows in private repositories
+      #actions: read
+      #contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - language: java-kotlin
+          build-mode: autobuild
+        # CodeQL supports the following values keywords for 'language': 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'swift'
+        # Use `c-cpp` to analyze code written in C, C++ or both
+        # Use 'java-kotlin' to analyze code written in Java, Kotlin or both
+        # Use 'javascript-typescript' to analyze code written in JavaScript, TypeScript or both
+        # To learn more about changing the languages that are analyzed or customizing the build mode for your analysis,
+        # see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning.
+        # If you are analyzing a compiled language, you can modify the 'build-mode' for that language to customize how
+        # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    # Add any setup steps before running the `github/codeql-action/init` action.
+    # This includes steps like installing compilers or runtimes (`actions/setup-node`
+    # or others). This is typically only required for manual builds.
+    # - name: Setup runtime (example)
+    #   uses: actions/setup-example@v1
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v3
+      with:
+        languages: ${{ matrix.language }}
+        build-mode: ${{ matrix.build-mode }}
+        # If you wish to specify custom queries, you can do so here or in a config file.
+        # By default, queries listed here will override any specified in a config file.
+        # Prefix the list here with "+" to use these queries and those in the config file.
+
+        # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+        # queries: security-extended,security-and-quality
+
+    # If the analyze step fails for one of the languages you are analyzing with
+    # "We were unable to automatically build your code", modify the matrix above
+    # to set the build mode to "manual" for that language. Then modify this step
+    # to build your code.
+    # ℹ️ Command-line programs to run using the OS shell.
+    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+    - if: matrix.build-mode == 'manual'
+      shell: bash
+      run: |
+        echo 'If you are using a "manual" build mode for one or more of the' \
+          'languages you are analyzing, replace this with the commands to build' \
+          'your code, for example:'
+        echo '  make bootstrap'
+        echo '  make release'
+        exit 1
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v3
+      with:
+        category: "/language:${{matrix.language}}"
+

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ bin/
 
 ### koci specific ###
 .registry
+
+# windsurf rules
+.windsurfrules

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="GradleMigrationSettings" migrationVersion="1" />
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="2.1.0" />
+    <option name="version" value="2.1.10" />
   </component>
 </project>

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .DEFAULT_GOAL := build
 
 ZARF_VERSION := "latest"
-ORAS_VERSION := "1.2.0"
+ORAS_VERSION := "1.2.2"
 ADDLICENSE_VERSION := "v1.1.1"
 ARCH := $(shell go env GOARCH)
 OS := $(shell go env GOOS)
@@ -10,31 +10,39 @@ OS := $(shell go env GOOS)
 build:
 	@ ./gradlew build
 
+.PHONY: test
 test: registry-up registry-seed
 	@ ./gradlew test --fail-fast
 
+.PHONY: lint
 lint:
 	@ ./gradlew detekt
 
+.PHONY: registry-up
 registry-up:
 	@ docker compose up -d
 
+.PHONY: registry-down
 registry-down:
 	@ docker compose down
 
+.PHONY: registry-reset
 registry-reset: registry-down
 	@ rm -r ./.registry/* 2>/dev/null || true
 	@ $(MAKE) registry-up registry-seed
 
+.PHONY: registry-seed
 registry-seed: registry-up
-	@ ./bin/zarf package publish oci://ghcr.io/zarf-dev/packages/dos-games:1.1.0 oci://localhost:5005 --insecure --oci-concurrency 5 --no-progress --no-log-file -a amd64
-	@ ./bin/zarf package publish oci://ghcr.io/zarf-dev/packages/dos-games:1.1.0 oci://localhost:5005 --insecure --oci-concurrency 5 --no-progress --no-log-file -a arm64
+	@ ./bin/zarf package publish oci://ghcr.io/zarf-dev/packages/dos-games:1.1.0 oci://localhost:5005 --plain-http --oci-concurrency 5 --no-progress --no-log-file -a amd64
+	@ ./bin/zarf package publish oci://ghcr.io/zarf-dev/packages/dos-games:1.1.0 oci://localhost:5005 --plain-http --oci-concurrency 5 --no-progress --no-log-file -a arm64
 	@ ./bin/oras cp docker.io/library/registry:2.8.0  localhost:5005/library/registry:2.8.0
 	@ ./bin/oras cp docker.io/library/registry:latest localhost:5005/library/registry:latest
 
+.PHONY: addlicense
 addlicense:
 	addlicense -l apache -s=only -v -c 'Defense Unicorns' src
 
+.PHONY: install-deps
 install-deps:
 	@ZARF_VERSION=$(ZARF_VERSION) \
 	ORAS_VERSION=$(ORAS_VERSION) \

--- a/src/main/kotlin/com/defenseunicorns/koci/DataClasses.kt
+++ b/src/main/kotlin/com/defenseunicorns/koci/DataClasses.kt
@@ -112,11 +112,6 @@ data class UploadStatus(
     var minChunkSize: Long,
 )
 
-interface Target {
-    suspend fun exists(descriptor: Descriptor): Result<Boolean>
-    suspend fun remove(descriptor: Descriptor): Result<Boolean>
-}
-
 sealed interface TaggableContent {
     val mediaType: String?
 }

--- a/src/main/kotlin/com/defenseunicorns/koci/Errors.kt
+++ b/src/main/kotlin/com/defenseunicorns/koci/Errors.kt
@@ -76,6 +76,9 @@ sealed class OCIException(message: String) : Exception(message) {
 
     class UnableToRemove(val descriptor: Descriptor, val reason: String) :
             OCIException("Unable to remove $descriptor: $reason")
+
+    class IncompletePull(ref: Reference):
+            OCIException("Pull operation completed, but was unsuccessful in validating $ref was pulled fully")
 }
 
 /**

--- a/src/main/kotlin/com/defenseunicorns/koci/Errors.kt
+++ b/src/main/kotlin/com/defenseunicorns/koci/Errors.kt
@@ -20,7 +20,7 @@ data class FailureResponse(
     var status: HttpStatusCode = HttpStatusCode(0, ErrorCode.UNKNOWN.toString()),
 )
 
-// https://distribution.github.io/distribution/spec/api/#errors-2
+// https://github.com/opencontainers/distribution-spec/blob/main/spec.md#error-codes
 enum class ErrorCode {
     UNKNOWN,
     BLOB_UNKNOWN,

--- a/src/main/kotlin/com/defenseunicorns/koci/Layout.kt
+++ b/src/main/kotlin/com/defenseunicorns/koci/Layout.kt
@@ -27,7 +27,7 @@ import java.util.concurrent.ConcurrentHashMap
 class Layout private constructor(
     internal val index: Index,
     private val root: String,
-) : Target {
+) {
     companion object {
         suspend fun create(root: String): Result<Layout> = withContext(Dispatchers.IO) {
             runCatching {
@@ -60,7 +60,7 @@ class Layout private constructor(
         }
     }
 
-    override suspend fun exists(descriptor: Descriptor): Result<Boolean> = runCatching {
+    suspend fun exists(descriptor: Descriptor): Result<Boolean> = runCatching {
         val file = blob(descriptor)
 
         val exists = withContext(Dispatchers.IO) {
@@ -133,7 +133,7 @@ class Layout private constructor(
     // TODO: ensure removals do not impact other images through unit tests
     @OptIn(ExperimentalSerializationApi::class)
     @Suppress("detekt:LongMethod", "detekt:CyclomaticComplexMethod")
-    override suspend fun remove(descriptor: Descriptor): Result<Boolean> = runCatching {
+    suspend fun remove(descriptor: Descriptor): Result<Boolean> = runCatching {
         val file = blob(descriptor)
 
         val exists = withContext(Dispatchers.IO) { file.exists() }

--- a/src/main/kotlin/com/defenseunicorns/koci/Layout.kt
+++ b/src/main/kotlin/com/defenseunicorns/koci/Layout.kt
@@ -33,14 +33,18 @@ class Layout private constructor(
             runCatching {
                 var index = Index()
                 val indexLocation = "$root/index.json"
+                val layoutFileLocation = "$root/oci-layout"
 
                 val rootDir = File(root)
                 if (!rootDir.exists()) {
                     rootDir.mkdirs()
-                    File("$root/oci-layout").writeText(Json.encodeToString(LayoutMarker("1.0.0")))
+                    File(layoutFileLocation).writeText(Json.encodeToString(LayoutMarker("1.0.0")))
                 } else {
                     require(rootDir.isDirectory) { "$root must be an existing directory" }
-                    // TODO: handle oci-layout version + existence checking
+                    // TODO: handle oci-layout version checking
+                    if (!File(layoutFileLocation).exists()) {
+                        File(layoutFileLocation).writeText(Json.encodeToString(LayoutMarker("1.0.0")))
+                    }
                 }
 
                 if (File(indexLocation).exists()) {

--- a/src/main/kotlin/com/defenseunicorns/koci/Layout.kt
+++ b/src/main/kotlin/com/defenseunicorns/koci/Layout.kt
@@ -312,7 +312,7 @@ class Layout private constructor(
                     || descriptor.mediaType == INDEX_MEDIA_TYPE
         )
         require(descriptor.size > 0)
-        require(reference.isNotEmpty())
+        reference.validate()
 
         val copy = descriptor.copy(
             annotations = descriptor.annotations?.plus(ANNOTATION_REF_NAME to reference.toString())

--- a/src/main/kotlin/com/defenseunicorns/koci/Layout.kt
+++ b/src/main/kotlin/com/defenseunicorns/koci/Layout.kt
@@ -308,6 +308,7 @@ class Layout private constructor(
                     || descriptor.mediaType == INDEX_MEDIA_TYPE
         )
         require(descriptor.size > 0)
+        require(reference.isNotEmpty())
 
         val copy = descriptor.copy(
             annotations = descriptor.annotations?.plus(ANNOTATION_REF_NAME to reference.toString())

--- a/src/main/kotlin/com/defenseunicorns/koci/Reference.kt
+++ b/src/main/kotlin/com/defenseunicorns/koci/Reference.kt
@@ -27,12 +27,14 @@ data class Reference(
     )
 
     companion object {
-        //	<--- path --------------------------------------------> |  - Decode `path`
-        //	<=== REPOSITORY ===> <--- reference ------------------> |    - Decode `reference`
-        //	<=== REPOSITORY ===> @ <=================== digest ===> |      - Valid Form A
-        //	<=== REPOSITORY ===> : <!!! TAG !!!> @ <=== digest ===> |      - Valid Form B (tag is dropped)
-        //	<=== REPOSITORY ===> : <=== TAG ======================> |      - Valid Form C
-        //	<=== REPOSITORY ======================================> |    - Valid Form D
+        /**
+         *    <--- path --------------------------------------------> |  - Decode `path`
+         *    <=== REPOSITORY ===> <--- reference ------------------> |  - Decode `reference`
+         *    <=== REPOSITORY ===> @ <=================== digest ===> |  - Valid Form A
+         *    <=== REPOSITORY ===> : <!!! TAG !!!> @ <=== digest ===> |  - Valid Form B (tag is dropped)
+         *    <=== REPOSITORY ===> : <=== TAG ======================> |  - Valid Form C
+         *    <=== REPOSITORY ======================================> |  - Valid Form D
+          */
         fun parse(artifact: String): Result<Reference> = runCatching {
             val reg = artifact.substringBefore("/", "")
             require(reg.isNotEmpty()) { "registry cannot be empty" }
@@ -98,5 +100,13 @@ data class Reference(
             return
         }
         Digest(reference)
+    }
+
+    fun isEmpty(): Boolean {
+        return this.registry.isEmpty() && this.reference.isEmpty() && this.repository.isEmpty()
+    }
+
+    fun isNotEmpty(): Boolean {
+        return this.registry.isNotEmpty() || this.reference.isNotEmpty() || this.repository.isNotEmpty()
     }
 }

--- a/src/main/kotlin/com/defenseunicorns/koci/Repository.kt
+++ b/src/main/kotlin/com/defenseunicorns/koci/Repository.kt
@@ -10,7 +10,6 @@ import io.ktor.client.call.*
 import io.ktor.client.plugins.*
 import io.ktor.client.request.*
 import io.ktor.http.*
-import io.ktor.utils.io.*
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.*
 import kotlinx.serialization.ExperimentalSerializationApi
@@ -43,10 +42,10 @@ class Repository(
     private val client: HttpClient,
     private val router: Router,
     private val name: String,
-) : Target {
+) {
     private val uploading = ConcurrentHashMap<Descriptor, UploadStatus>()
 
-    override suspend fun exists(descriptor: Descriptor): Result<Boolean> = runCatching {
+    suspend fun exists(descriptor: Descriptor): Result<Boolean> = runCatching {
         val endpoint = when (descriptor.mediaType) {
             MANIFEST_MEDIA_TYPE,
             INDEX_MEDIA_TYPE,
@@ -127,7 +126,7 @@ class Repository(
      *
      * TODO: Similarly, a registry MAY implement tag deletion, while others MAY allow deletion only by manifest.
      */
-    override suspend fun remove(descriptor: Descriptor) = runCatching {
+    suspend fun remove(descriptor: Descriptor) = runCatching {
         val endpoint = when (descriptor.mediaType) {
             MANIFEST_MEDIA_TYPE,
             INDEX_MEDIA_TYPE,

--- a/src/main/kotlin/com/defenseunicorns/koci/Router.kt
+++ b/src/main/kotlin/com/defenseunicorns/koci/Router.kt
@@ -62,6 +62,8 @@ class Router(registryURL: String) {
             return URLBuilder().takeFrom(locationHeader).build()
         }
 
-        return base.clone().appendPathSegments(locationHeader).build()
+        return URLBuilder().takeFrom(base.build()).apply {
+            encodedPath = locationHeader
+        }.build()
     }
 }

--- a/src/test/kotlin/com/defenseunicorns/koci/ReferenceTest.kt
+++ b/src/test/kotlin/com/defenseunicorns/koci/ReferenceTest.kt
@@ -11,7 +11,7 @@ import kotlin.test.*
 
 class ReferenceTest {
     @Test
-    @Suppress("detekt:MaxLineLength")
+    @Suppress("detekt:MaxLineLength", "detekt:LongMethod")
     fun good() {
         val testCases = mapOf(
             // valid form A

--- a/src/test/kotlin/com/defenseunicorns/koci/ReferenceTest.kt
+++ b/src/test/kotlin/com/defenseunicorns/koci/ReferenceTest.kt
@@ -6,9 +6,8 @@
 package com.defenseunicorns.koci
 
 import io.ktor.http.*
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
+import org.junit.jupiter.api.assertDoesNotThrow
+import kotlin.test.*
 
 class ReferenceTest {
     @Test
@@ -54,8 +53,20 @@ class ReferenceTest {
         for ((tc, want) in testCases) {
             val got = Reference.parse(tc).getOrThrow()
             assertEquals(want.first, got)
+            assertTrue(got.isNotEmpty())
+            assertFalse(got.isEmpty())
 
             assertEquals(want.second, got.toString())
+
+            if (got.reference.startsWith("sha256")) {
+                assertDoesNotThrow {
+                    got.digest()
+                }
+            } else {
+                assertFailsWith<IllegalArgumentException> {
+                    got.digest()
+                }
+            }
         }
 
         val urlTestCase = Reference(
@@ -65,6 +76,18 @@ class ReferenceTest {
         )
 
         assertEquals("localhost:5005/repo:tag", urlTestCase.toString())
+
+        assertTrue(Reference("", "", "").isEmpty())
+        assertFalse(Reference("", "", "").isNotEmpty())
+        val partialEmpties = listOf(
+            Reference("a", "", ""),
+            Reference("", "b", ""),
+            Reference("", "", "c")
+        )
+        for (ref in partialEmpties) {
+            assertTrue(ref.isNotEmpty())
+            assertFalse(ref.isEmpty())
+        }
     }
 
     @Test

--- a/src/test/kotlin/com/defenseunicorns/koci/RegistryTest.kt
+++ b/src/test/kotlin/com/defenseunicorns/koci/RegistryTest.kt
@@ -56,6 +56,12 @@ class RegistryTest {
         Layout.create(tmp.toString())
     }.getOrThrow()
 
+    @Test
+    fun `layout creation`() {
+        assertEquals(emptyList(), storage.catalog())
+        assertEquals(LayoutMarker("1.0.0"), Json.decodeFromString(File("$tmp/oci-layout").readText()))
+    }
+
     private val registry = Registry("http://127.0.0.1:5005", httpClient) // matches docker-compose.yaml
 
     @Test

--- a/src/test/kotlin/com/defenseunicorns/koci/RegistryTest.kt
+++ b/src/test/kotlin/com/defenseunicorns/koci/RegistryTest.kt
@@ -132,11 +132,13 @@ class RegistryTest {
 
     @Test
     fun resolve() = runTest {
-        val result = registry.repo("dos-games").resolve("1.1.0")
-        assertTrue(result.isSuccess)
-        val desc = result.getOrThrow()
-        // TODO (razzle): bad litmus test, make better
-        assertEquals(desc.mediaType, INDEX_MEDIA_TYPE)
+        assertEquals(INDEX_MEDIA_TYPE, registry.repo("dos-games").resolve("1.1.0").getOrThrow().mediaType)
+        assertEquals(MANIFEST_MEDIA_TYPE, registry.repo("dos-games").resolve("1.1.0") { platform ->
+            platform.os == "multi"
+        }.getOrThrow().mediaType)
+        assertFailsWith<OCIException.ManifestNotSupported>{
+            registry.repo("library/registry").resolve("2.8.0").getOrThrow()
+        }
     }
 
     @Test

--- a/src/test/kotlin/com/defenseunicorns/koci/RegistryTest.kt
+++ b/src/test/kotlin/com/defenseunicorns/koci/RegistryTest.kt
@@ -119,7 +119,7 @@ class RegistryTest {
 
         val all = mutableListOf(
             TagsResponse("dos-games", listOf("1.1.0")),
-            TagsResponse("library/registry", listOf("latest", "2.8.0")),
+            TagsResponse("library/registry", listOf("2.8.0", "latest")),
             TagsResponse("test-upload", null),
         )
 

--- a/src/test/kotlin/com/defenseunicorns/koci/RegistryTest.kt
+++ b/src/test/kotlin/com/defenseunicorns/koci/RegistryTest.kt
@@ -131,7 +131,9 @@ class RegistryTest {
 
         for ((idx, value) in record.withIndex()) {
             assertTrue(value.isSuccess, value.exceptionOrNull()?.message)
-            assertEquals(all[idx], value.getOrThrow())
+            // tags is sometimes a non-deterministic sorted list, or bluefin is just wacky
+            assertEquals(all[idx].tags?.sorted(), value.getOrThrow().tags?.sorted())
+            assertEquals(all[idx].name, value.getOrThrow().name)
         }
         assertEquals(all.size, record.size)
     }

--- a/src/test/kotlin/com/defenseunicorns/koci/RouteTest.kt
+++ b/src/test/kotlin/com/defenseunicorns/koci/RouteTest.kt
@@ -85,4 +85,17 @@ class RouteTest {
             ).toString()
         )
     }
+
+    @Test
+    fun uploads() {
+        assertEquals("http://127.0.0.1:5000/v2/foo/blobs/uploads/", router.uploads("foo").toString())
+    }
+
+    @Test
+    fun `parse upload location`() {
+        val abs = "http://127.0.0.1:5000/v2/test-upload/blobs/uploads/4e67c002-da9b-432e-a410-79b403bfcd87?_state=DGT2TjfmtQaET0K3qfXpO_4am5scH987hejkECPV2Ep7Ik5hbWUiOiJ0ZXN0LXVwbG9hZCIsIlVVSUQiOiI0ZTY3YzAwMi1kYTliLTQzMmUtYTQxMC03OWI0MDNiZmNkODciLCJPZmZzZXQiOjE1NzI4NjQwLCJTdGFydGVkQXQiOiIyMDI1LTAyLTIxVDE4OjQwOjMyWiJ9"
+        val rel = "/v2/test-upload/blobs/uploads/4e67c002-da9b-432e-a410-79b403bfcd87?_state=DGT2TjfmtQaET0K3qfXpO_4am5scH987hejkECPV2Ep7Ik5hbWUiOiJ0ZXN0LXVwbG9hZCIsIlVVSUQiOiI0ZTY3YzAwMi1kYTliLTQzMmUtYTQxMC03OWI0MDNiZmNkODciLCJPZmZzZXQiOjE1NzI4NjQwLCJTdGFydGVkQXQiOiIyMDI1LTAyLTIxVDE4OjQwOjMyWiJ9"
+        assertEquals(abs, router.parseUploadLocation(abs).toString())
+        assertEquals(abs, router.parseUploadLocation(rel).toString())
+    }
 }


### PR DESCRIPTION
- Adds codeql config
- Increases test coverage to 80%+
- Removes usages of `Flow<Result<T>>` in favor of `Flow<T>` as flow has error handling semantics
- Cleans up some flaky tests
- Remove dead code
- `pull` checks for manifest descriptor existence before tagging
- Adds a simple test around `oci-layout` marker
