### PR TITLE
feat: javadoc and default request timeout

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,7 +34,7 @@ jobs:
           echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
           make install-deps
           make lint
-          make test
+          make test-all
 
       - if: failure()
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,10 @@ build:
 test: registry-up registry-seed
 	@ ./gradlew test --fail-fast
 
+.PHONY: test-all
+test-all: registry-up registry-seed
+	@ ./gradlew allTests --fail-fast
+
 .PHONY: lint
 lint:
 	@ ./gradlew detekt

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -87,6 +87,11 @@ kover {
     }
 }
 
+java {
+    withJavadocJar()
+    withSourcesJar()
+}
+
 publishing {
     repositories {
         maven {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -112,3 +112,10 @@ publishing {
         }
     }
 }
+
+
+
+tasks.register<Test>("allTests") {
+    systemProperty("TESTS_WITH_EXTERNAL_SERVICES", "true")
+    useJUnitPlatform()
+}

--- a/src/main/kotlin/com/defenseunicorns/koci/Registry.kt
+++ b/src/main/kotlin/com/defenseunicorns/koci/Registry.kt
@@ -14,6 +14,8 @@ import io.ktor.http.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.*
 import kotlinx.serialization.json.Json
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
 
 /**
  * Registry is the main entrypoint for koci's operations.
@@ -22,6 +24,7 @@ import kotlinx.serialization.json.Json
  */
 class Registry(
     registryURL: String,
+    val requestTimeout: Duration = 10.minutes,
     var client: HttpClient = HttpClient(CIO),
 ) {
     val router = Router(registryURL)
@@ -41,6 +44,10 @@ class Registry(
                     attemptThrow4XX(clientException.response)
                     return@handleResponseExceptionWithRequest
                 }
+            }
+
+            install(HttpTimeout) {
+                this.requestTimeoutMillis = requestTimeout.inWholeMilliseconds
             }
 
             expectSuccess = true

--- a/src/test/kotlin/com/defenseunicorns/koci/RegistryTest.kt
+++ b/src/test/kotlin/com/defenseunicorns/koci/RegistryTest.kt
@@ -296,13 +296,15 @@ class RegistryTest {
 
     @Test
     @EnabledIfSystemProperty(named = "TESTS_WITH_EXTERNAL_SERVICES", matches = "true")
-    fun `pull and remove gradle`() = runTest(timeout = 10.minutes) {
+    fun `pull and remove gradle from dockerhub`() = runTest(timeout = 10.minutes) {
         val registry = Registry("https://registry-1.docker.io")
         val prog = registry.pull("library/gradle", "latest", storage)
 
         assertEquals(
             100, prog.last()
         )
+
+        assertTrue(storage.remove(Reference.parse("registry-1.docker.io/library/gradle:latest").getOrThrow()).isSuccess)
     }
 
     @Test

--- a/src/test/kotlin/com/defenseunicorns/koci/RegistryTest.kt
+++ b/src/test/kotlin/com/defenseunicorns/koci/RegistryTest.kt
@@ -20,6 +20,7 @@ import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.decodeFromStream
 import org.junit.jupiter.api.*
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty
 import java.io.File
 import java.io.FileOutputStream
 import java.util.concurrent.Executors
@@ -30,6 +31,7 @@ import kotlin.io.path.deleteRecursively
 import kotlin.random.Random
 import kotlin.test.*
 import kotlin.test.Test
+import kotlin.time.Duration.Companion.minutes
 
 const val TEST_BLOB_MEDIATYPE = "application/vnd.koci.test.blob.v1+text"
 
@@ -62,7 +64,7 @@ class RegistryTest {
         assertEquals(LayoutMarker("1.0.0"), Json.decodeFromString(File("$tmp/oci-layout").readText()))
     }
 
-    private val registry = Registry("http://127.0.0.1:5005", httpClient) // matches docker-compose.yaml
+    private val registry = Registry("http://127.0.0.1:5005", client = httpClient) // matches docker-compose.yaml
 
     @Test
     fun `can ping`() = runTest {
@@ -293,6 +295,17 @@ class RegistryTest {
     }
 
     @Test
+    @EnabledIfSystemProperty(named = "TESTS_WITH_EXTERNAL_SERVICES", matches = "true")
+    fun `pull and remove gradle`() = runTest(timeout = 10.minutes) {
+        val registry = Registry("https://registry-1.docker.io")
+        val prog = registry.pull("library/gradle", "latest", storage)
+
+        assertEquals(
+            100, prog.last()
+        )
+    }
+
+    @Test
     fun `resume-able pulls`() = runTest {
         val desc = registry.resolve("dos-games", "1.1.0").getOrThrow()
         val amd64Resolver = { plat: Platform ->
@@ -388,9 +401,9 @@ class RegistryTest {
 
         assertTrue { repo.exists(tmp10Desc).getOrThrow() }
         assertTrue { repo.remove(desc).getOrThrow() }
-        assertFailsWith<ClientRequestException>{ repo.exists(desc).getOrThrow() }
+        assertFailsWith<ClientRequestException> { repo.exists(desc).getOrThrow() }
         assertTrue { repo.remove(tmp10Desc).getOrThrow() }
-        assertFailsWith<ClientRequestException>{ !repo.exists(tmp10Desc).getOrThrow() }
+        assertFailsWith<ClientRequestException> { !repo.exists(tmp10Desc).getOrThrow() }
 
         val tmp15 = tmp.resolve("15mb.txt").absolutePathString()
         val tmp15Desc = generateRandomFile(tmp15, 15 * 1024 * 1024 + 300)
@@ -446,12 +459,12 @@ class RegistryTest {
 
     @Test
     fun `public scopes`() = runTest {
-        val ecr = Registry("https://public.ecr.aws", httpClient)
+        val ecr = Registry("https://public.ecr.aws", client = httpClient)
 
         val result = ecr.repo("ubuntu/redis").tags()
         assertTrue(result.isSuccess, result.exceptionOrNull().toString())
 
-        val nvcr = Registry("https://nvcr.io", httpClient)
+        val nvcr = Registry("https://nvcr.io", client = httpClient)
 
         nvcr.tags("nvidia/l4t-pytorch").getOrThrow()
     }


### PR DESCRIPTION
Relates to #50

changes and their reasoning:

**Source und JavaDoc publishin**: is always a must have, specially if the lib is open source anyways.
**(default) Request timeout**: while using your lib i ran into a timeout on my first image pull attempt (gradle image). this change aims to apply a sensible default and make it easily configurable, to prevent such issues.
**the image pull from dockerhub test**: to test my issue, and also donate a fix for #50 while i was at it anyway


