### PR TITLE
fix: remove deprecated zarf flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,8 +33,8 @@ registry-reset: registry-down
 
 .PHONY: registry-seed
 registry-seed: registry-up
-	@ ./bin/zarf package publish oci://ghcr.io/zarf-dev/packages/dos-games:1.1.0 oci://localhost:5005 --plain-http --oci-concurrency 5 --no-progress --no-log-file -a amd64
-	@ ./bin/zarf package publish oci://ghcr.io/zarf-dev/packages/dos-games:1.1.0 oci://localhost:5005 --plain-http --oci-concurrency 5 --no-progress --no-log-file -a arm64
+	@ ./bin/zarf package publish oci://ghcr.io/zarf-dev/packages/dos-games:1.1.0 oci://localhost:5005 --plain-http -a amd64
+	@ ./bin/zarf package publish oci://ghcr.io/zarf-dev/packages/dos-games:1.1.0 oci://localhost:5005 --plain-http -a arm64
 	@ ./bin/oras cp docker.io/library/registry:2.8.0  localhost:5005/library/registry:2.8.0
 	@ ./bin/oras cp docker.io/library/registry:latest localhost:5005/library/registry:latest
 


### PR DESCRIPTION
Zarf updated its flags and now fails if `--no-log-file` is present.

Purposefully _not_ pinning Zarf as I want CI to fail if behavior in Zarf changes unexpectedly. Since upstream fixes are timely and easily accomplished, I'm fine feeling a bit more pain on this project.
