### PR TITLE
ci: add requirements for maven central publishing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -45,3 +45,7 @@ jobs:
         run: ./gradlew publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USER }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_TOKEN }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_SECRET_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_SECRET_PASSPHRASE }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,6 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created == 'true'}}
+    environment: release
     permissions:
       packages: write
       contents: read

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="2.1.10" />
+    <option name="version" value="2.1.20" />
   </component>
 </project>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,4 @@
+import com.vanniktech.maven.publish.SonatypeHost
 import io.gitlab.arturbosch.detekt.Detekt
 import kotlinx.kover.gradle.plugin.dsl.AggregationType
 import kotlinx.kover.gradle.plugin.dsl.CoverageUnit
@@ -15,8 +16,7 @@ plugins {
     alias(libs.plugins.kover)
     alias(libs.plugins.detekt)
 
-    id("maven-publish")
-    id("signing")
+    alias(libs.plugins.maven.publish)
 }
 
 buildscript {
@@ -87,9 +87,39 @@ kover {
     }
 }
 
-java {
-    withJavadocJar()
-    withSourcesJar()
+val releasePleaseManifest = file(".release-please-manifest.json")
+
+version = Json.decodeFromString<JsonElement>(releasePleaseManifest.readText()).jsonObject["."]?.jsonPrimitive?.content!!
+
+mavenPublishing {
+    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL, automaticRelease = true)
+    signAllPublications()
+
+    pom {
+        name = project.name
+        description = "Kotlin implementation of the OCI Distribution client specification"
+        url = "https://github.com/defenseunicorns/koci"
+
+        licenses {
+            license {
+                name = "The Apache License, Version 2.0"
+                url = "http://www.apache.org/licenses/LICENSE-2.0.txt"
+                distribution = "repo"
+            }
+        }
+
+        developers {
+            developer {
+                name = "Defense Unicorns"
+            }
+        }
+
+        scm {
+            connection = "scm:git:git://github.com/defenseunicorns/koci.git"
+            developerConnection = "scm:git:ssh://github.com/defenseunicorns/koci.git"
+            url = "https://github.com/defenseunicorns/koci"
+        }
+    }
 }
 
 publishing {
@@ -102,59 +132,7 @@ publishing {
                 password = System.getenv("GITHUB_TOKEN")
             }
         }
-        maven {
-            name = "MavenCentralStaging"
-            url = URI("https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/")
-            credentials {
-                username = System.getenv("MAVEN_CENTRAL_USER")
-                password = System.getenv("MAVEN_CENTRAL_TOKEN")
-            }
-        }
     }
-    publications {
-        val releasePleaseManifest = file(".release-please-manifest.json")
-        create<MavenPublication>("maven") {
-            version =
-                Json.decodeFromString<JsonElement>(releasePleaseManifest.readText()).jsonObject["."]?.jsonPrimitive?.content
-
-            from(components["java"])
-
-            pom {
-                name = "koci"
-                description = "Kotlin implementation of the OCI Distribution client specification"
-                url = "https://github.com/defenseunicorns/koci"
-
-                licenses {
-                    license {
-                        name = "The Apache License, Version 2.0"
-                        url = "http://www.apache.org/licenses/LICENSE-2.0.txt"
-                    }
-                }
-
-                developers {
-                    developer {
-                        id = "defenseunicorns"
-                        name = "Defense Unicorns"
-                        email = "hello@defenseunicorns.com"
-                    }
-                }
-
-                scm {
-                    connection = "scm:git:git://github.com/defenseunicorns/koci.git"
-                    developerConnection = "scm:git:ssh://github.com/defenseunicorns/koci.git"
-                    url = "https://github.com/defenseunicorns/koci"
-                }
-            }
-        }
-    }
-}
-
-signing {
-    sign(publishing.publications["maven"])
-}
-
-tasks.withType<Sign>().configureEach {
-    dependsOn(tasks.withType<Jar>())
 }
 
 tasks.register<Test>("allTests") {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,7 @@ ktorSerializationKotlinxJson = "3.1.2"
 kover = "0.9.1"
 detekt = "1.23.8"
 detektFormatting = "1.23.8"
+mavenPublish = "0.31.0"
 
 [libraries]
 detekt-formatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "detektFormatting" }
@@ -25,3 +26,4 @@ detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
 jetbrains-kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+maven-publish = { id = "com.vanniktech.maven.publish", version.ref = "mavenPublish" }


### PR DESCRIPTION
Relates to #85 

Follows docs from https://central.sonatype.org/publish/publish-portal-maven/ and https://docs.gradle.org/current/userguide/publishing_maven.html
