### PR TITLE
chore: improve concurrent descriptor pulls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,5 +44,8 @@ bin/
 ### koci specific ###
 .registry
 
-# windsurf rules
+### Windsurf rules ###
 .windsurfrules
+
+### Kotlin ###
+.kotlin

--- a/src/test/kotlin/com/defenseunicorns/koci/RegistryTest.kt
+++ b/src/test/kotlin/com/defenseunicorns/koci/RegistryTest.kt
@@ -401,7 +401,6 @@ class RegistryTest {
             }
         }
 
-        // Test concurrent removes of the same descriptor
         assertDoesNotThrow {
             runTest(timeout = kotlin.time.Duration.parse("PT2M")) {
                 val descriptor = registry.resolve("dos-games", "1.1.0").getOrThrow()

--- a/src/test/kotlin/com/defenseunicorns/koci/RegistryTest.kt
+++ b/src/test/kotlin/com/defenseunicorns/koci/RegistryTest.kt
@@ -387,7 +387,6 @@ class RegistryTest {
 
         assertDoesNotThrow {
             runTest(timeout = kotlin.time.Duration.parse("PT2M")) {
-                // Pull the same image twice in parallel
                 val p1 = async {
                     registry.pull("dos-games", "1.1.0", storage).collect()
                 }

--- a/src/test/kotlin/com/defenseunicorns/koci/RegistryTest.kt
+++ b/src/test/kotlin/com/defenseunicorns/koci/RegistryTest.kt
@@ -360,6 +360,12 @@ class RegistryTest {
                     registry.pull("library/registry", "latest", storage).collect()
                 }
                 awaitAll(p1, p2)
+
+                // Verify both images exist
+                val d1 = registry.resolve("dos-games", "1.1.0").getOrThrow()
+                assertTrue(storage.exists(d1).getOrThrow())
+                val d2 = registry.resolve("library/registry", "latest").getOrThrow()
+                assertTrue(storage.exists(d2).getOrThrow())
             }
         }
 
@@ -374,6 +380,27 @@ class RegistryTest {
                     storage.remove(d2).getOrThrow()
                 }
                 awaitAll(r1, r2)
+
+                // Verify both images are removed
+                assertFalse(storage.exists(d1).getOrThrow())
+                assertFalse(storage.exists(d2).getOrThrow())
+            }
+        }
+
+        assertDoesNotThrow {
+            runTest(timeout = kotlin.time.Duration.parse("PT2M")) {
+                // Pull the same image twice in parallel
+                val p1 = async {
+                    registry.pull("dos-games", "1.1.0", storage).collect()
+                }
+                val p2 = async {
+                    registry.pull("dos-games", "1.1.0", storage).collect()
+                }
+                awaitAll(p1, p2)
+
+                // Verify the image exists
+                val descriptor = registry.resolve("dos-games", "1.1.0").getOrThrow()
+                assertTrue(storage.exists(descriptor).getOrThrow())
             }
         }
     }


### PR DESCRIPTION
Fixes #106

Improves concurrency for multiple of the same descriptor being pulled at once.
