### PR TITLE
fix: offset byte issue with chunked uploads

### DIFF
--- a/src/main/kotlin/com/defenseunicorns/koci/Repository.kt
+++ b/src/main/kotlin/com/defenseunicorns/koci/Repository.kt
@@ -608,9 +608,9 @@ class Repository(
 
                             val status = res.headers.toUploadStatus()
                             uploading[expected] = status
-                            offset = status.offset
+                            offset = status.offset + 1
 
-                            send(offset + 1)
+                            send(offset)
 
                             yield()
                         }

--- a/src/test/kotlin/com/defenseunicorns/koci/RegistryTest.kt
+++ b/src/test/kotlin/com/defenseunicorns/koci/RegistryTest.kt
@@ -406,17 +406,23 @@ class RegistryTest {
 
         assertTrue { repo.exists(desc).getOrThrow() }
 
-        val tmp10 = tmp.resolve("10mb.txt").absolutePathString()
+        val tmp11 = tmp.resolve("11mb.txt").absolutePathString()
 
-        val tmp10Desc = generateRandomFile(tmp10, 10 * 1024 * 1024)
+        /**
+         * 11mb causes a POST, PATCH, PATCH, PUT
+         * 10mb only causes a POST, PATCH, PUT
+         *
+         * Ensures that offsets are calculated correctly on PATCH
+         */
+        val tmp11Desc = generateRandomFile(tmp11, 11 * 1024 * 1024)
 
-        repo.push(File(tmp10).inputStream(), tmp10Desc).collect()
+        repo.push(File(tmp11).inputStream(), tmp11Desc).collect()
 
-        assertTrue { repo.exists(tmp10Desc).getOrThrow() }
+        assertTrue { repo.exists(tmp11Desc).getOrThrow() }
         assertTrue { repo.remove(desc).getOrThrow() }
         assertFailsWith<ClientRequestException> { repo.exists(desc).getOrThrow() }
-        assertTrue { repo.remove(tmp10Desc).getOrThrow() }
-        assertFailsWith<ClientRequestException> { !repo.exists(tmp10Desc).getOrThrow() }
+        assertTrue { repo.remove(tmp11Desc).getOrThrow() }
+        assertFailsWith<ClientRequestException> { !repo.exists(tmp11Desc).getOrThrow() }
 
         val tmp15 = tmp.resolve("15mb.txt").absolutePathString()
         val tmp15Desc = generateRandomFile(tmp15, 15 * 1024 * 1024 + 300)


### PR DESCRIPTION
When working with the `koci` library, we found that resumable uploads were causing a:

```
invalid: 416 Requested Range Not Satisfiable. Text: "{"errors":\[{"code":"RANGE_INVALID","message":"invalid content range"}]}
```

The `blob` we were working with was over the `chunk` limit, so when a resumable upload was triggered, we were hitting this. We found that setting `offset` was not being properly set and missing a `+ 1` to it's value. But it was happening in the `send()`.

So once a second `PATCH` started, the `offset` was off by `1`, and the error occurred.

The test we updated did not catch this since `10mb` did not cause a second `PATCH` to fire off, thus this path was not getting triggered. We updated it to `11mb` which exasperated the issue.

Thanks to @Racer159 and @sgettys for finding the byte issues!

