### PR TITLE
fix!: registry progress int overflow

### DIFF
--- a/src/main/kotlin/com/defenseunicorns/koci/Layout.kt
+++ b/src/main/kotlin/com/defenseunicorns/koci/Layout.kt
@@ -311,7 +311,7 @@ class Layout private constructor(
      * @throws OCIException.SizeMismatch if the final size doesn't match the descriptor
      * @throws OCIException.DigestMismatch if the final digest doesn't match the descriptor
      */
-    fun push(descriptor: Descriptor, stream: InputStream): Flow<Int> = channelFlow {
+    fun push(descriptor: Descriptor, stream: InputStream): Flow<Long> = channelFlow {
         val (mu, refCount) = pushing.computeIfAbsent(descriptor) {
             Pair(Mutex(), AtomicInteger(0))
         }
@@ -351,7 +351,7 @@ class Layout private constructor(
                                 md.update(buffer, 0, bytesRead)
                                 out.write(buffer, 0, bytesRead)
 
-                                send(bytesRead)
+                                send(bytesRead.toLong())
                                 yield()
                             }
                         }

--- a/src/main/kotlin/com/defenseunicorns/koci/Repository.kt
+++ b/src/main/kotlin/com/defenseunicorns/koci/Repository.kt
@@ -367,11 +367,12 @@ class Repository(
 
         var completedManifestsBytes = 0L
         index.manifests.forEach { manifestDescriptor ->
-            val finalManifest = pull(manifestDescriptor, store).fold(0L) { _, currManifestBytes ->
+            var manifestBytes = 0L
+            pull(manifestDescriptor, store).collect { currManifestBytes ->
+                manifestBytes = currManifestBytes
                 channel.send(completedManifestsBytes + currManifestBytes)
-                currManifestBytes
             }
-            completedManifestsBytes += finalManifest
+            completedManifestsBytes += manifestBytes
         }
 
         copy(descriptor, store).collect()

--- a/src/test/kotlin/com/defenseunicorns/koci/RegistryTest.kt
+++ b/src/test/kotlin/com/defenseunicorns/koci/RegistryTest.kt
@@ -216,7 +216,7 @@ class RegistryTest {
             repo.manifest(index.manifests.first()).getOrThrow().layers.maxBy { it.size }
         }.getOrThrow()
 
-        val cancelAtBytes = listOf(layer.size.toInt() / 4, layer.size.toInt() / 2, -100)
+        val cancelAtBytes = listOf(layer.size / 4, layer.size / 2, Long.MAX_VALUE)
 
         assertFalse { storage.exists(layer).getOrDefault(false) }
 
@@ -224,7 +224,7 @@ class RegistryTest {
             var bytesPulled = 0L
             launch {
                 repo.pull(layer, storage).onCompletion { e ->
-                    if (at == -100) {
+                    if (at == Long.MAX_VALUE) {
                         assertNull(e)
                         assertEquals(layer.size, bytesPulled)
                     } else {
@@ -264,7 +264,7 @@ class RegistryTest {
         val prog = registry.pull("dos-games", "1.1.0", storage)
 
         assertEquals(
-            100, prog.last()
+            7474574, prog.last()
         )
 
         val ref = Reference.parse("127.0.0.1:5005/dos-games:1.1.0").getOrThrow()
@@ -313,8 +313,8 @@ class RegistryTest {
         }
 
         val dispatcher = Executors.newFixedThreadPool(2).asCoroutineDispatcher()
-        // ~5%, ~15%, ~50%, ~-100%, ~1000% (should complete and not cancel)
-        val cancelPoints = listOf(186426L, 559279L, 1864263L, -3728527L, 37285270L)
+        // ~5%, ~15%, ~50%, COMPLETE
+        val cancelPoints = listOf(186426L, 559279L, 1864263L, Long.MAX_VALUE)
 
         dispatcher.use { d ->
             for (cancelAt in cancelPoints) {

--- a/src/test/kotlin/com/defenseunicorns/koci/RegistryTest.kt
+++ b/src/test/kotlin/com/defenseunicorns/koci/RegistryTest.kt
@@ -299,7 +299,7 @@ class RegistryTest {
         val prog = registry.pull("library/gradle", "latest", storage)
 
         assertEquals(
-            100, prog.last()
+            1753448172, prog.last()
         )
 
         assertTrue(storage.remove(Reference.parse("registry-1.docker.io/library/gradle:latest").getOrThrow()).isSuccess)

--- a/src/test/kotlin/com/defenseunicorns/koci/RegistryTest.kt
+++ b/src/test/kotlin/com/defenseunicorns/koci/RegistryTest.kt
@@ -294,15 +294,15 @@ class RegistryTest {
 
     @Test
     @EnabledIfSystemProperty(named = "TESTS_WITH_EXTERNAL_SERVICES", matches = "true")
-    fun `pull and remove gradle from dockerhub`() = runTest(timeout = 10.minutes) {
-        val registry = Registry("https://registry-1.docker.io")
-        val prog = registry.pull("library/gradle", "latest", storage)
+    fun `pull and remove zarf agent from ghcr`() = runTest(timeout = 10.minutes) {
+        val registry = Registry("https://ghcr.io")
+        val prog = registry.pull("zarf-dev/zarf/agent", "v0.63.0", storage)
 
         assertEquals(
-            1753448172, prog.last()
+            108648729, prog.last()
         )
 
-        assertTrue(storage.remove(Reference.parse("registry-1.docker.io/library/gradle:latest").getOrThrow()).isSuccess)
+        assertTrue(storage.remove(Reference.parse("ghcr.io/zarf-dev/zarf/agent:v0.63.0").getOrThrow()).isSuccess)
     }
 
     @Test


### PR DESCRIPTION
Fixes #N/A

This addresses a bug where OCI artifacts which are larger than 2,147,483,647 bytes (~2.1GB) would overflow and show negative progress.

> [!CAUTION]
> **BREAKING CHANGE**
> This also changes the progress on a registry pull to show raw bytes so that clients can make more informed decisions on what to do with the progress.
