### PR TITLE
chore: removed workflows only running on main

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -10,7 +10,6 @@ on:
   push:
     branches: [ "main" ]
   pull_request:
-    branches: [ "main" ]
     types: [ milestoned, opened, edited, synchronize ]
   schedule:
     - cron: '41 1 * * 5'

--- a/.github/workflows/commitlint.yaml
+++ b/.github/workflows/commitlint.yaml
@@ -1,9 +1,7 @@
 name: Commitlint
 
 on:
-  # This workflow is triggered on pull requests to the main branch.
   pull_request:
-    branches: [ main ]
     # milestoned is added here as a workaround for release-please not triggering PR workflows (PRs should be added to a milestone to trigger the workflow).
     types: [ milestoned, opened, edited, synchronize ]
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,9 +1,7 @@
 name: Lint
 
 on:
-  # This workflow is triggered on pull requests to the main branch.
   pull_request:
-    branches: [ main ]
     # milestoned is added here as a workaround for release-please not triggering PR workflows (PRs should be added to a milestone to trigger the workflow).
     types: [ milestoned, opened, edited, synchronize ]
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,8 +1,6 @@
 name: Test
 on:
-  # This workflow is triggered on pull requests to the main branch.
   pull_request:
-    branches: [ main ]
     # milestoned is added here as a workaround for release-please not triggering PR workflows (PRs should be added to a milestone to trigger the workflow).
     types: [ milestoned, opened, edited, synchronize ]
   push:

--- a/src/main/kotlin/com/defenseunicorns/koci/Annotations.kt
+++ b/src/main/kotlin/com/defenseunicorns/koci/Annotations.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 Defense Unicorns
+ * Copyright 2024-2026 Defense Unicorns
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/src/main/kotlin/com/defenseunicorns/koci/Auth.kt
+++ b/src/main/kotlin/com/defenseunicorns/koci/Auth.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 Defense Unicorns
+ * Copyright 2024-2026 Defense Unicorns
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/src/main/kotlin/com/defenseunicorns/koci/DataClasses.kt
+++ b/src/main/kotlin/com/defenseunicorns/koci/DataClasses.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 Defense Unicorns
+ * Copyright 2024-2026 Defense Unicorns
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/src/main/kotlin/com/defenseunicorns/koci/Digest.kt
+++ b/src/main/kotlin/com/defenseunicorns/koci/Digest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 Defense Unicorns
+ * Copyright 2024-2026 Defense Unicorns
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/src/main/kotlin/com/defenseunicorns/koci/Errors.kt
+++ b/src/main/kotlin/com/defenseunicorns/koci/Errors.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 Defense Unicorns
+ * Copyright 2024-2026 Defense Unicorns
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/src/main/kotlin/com/defenseunicorns/koci/Layout.kt
+++ b/src/main/kotlin/com/defenseunicorns/koci/Layout.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 Defense Unicorns
+ * Copyright 2024-2026 Defense Unicorns
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/src/main/kotlin/com/defenseunicorns/koci/Reference.kt
+++ b/src/main/kotlin/com/defenseunicorns/koci/Reference.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 Defense Unicorns
+ * Copyright 2024-2026 Defense Unicorns
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/src/main/kotlin/com/defenseunicorns/koci/Registry.kt
+++ b/src/main/kotlin/com/defenseunicorns/koci/Registry.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 Defense Unicorns
+ * Copyright 2024-2026 Defense Unicorns
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/src/main/kotlin/com/defenseunicorns/koci/Repository.kt
+++ b/src/main/kotlin/com/defenseunicorns/koci/Repository.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 Defense Unicorns
+ * Copyright 2024-2026 Defense Unicorns
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/src/main/kotlin/com/defenseunicorns/koci/Router.kt
+++ b/src/main/kotlin/com/defenseunicorns/koci/Router.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Defense Unicorns
+ * Copyright 2025-2026 Defense Unicorns
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/src/main/kotlin/com/defenseunicorns/koci/Scopes.kt
+++ b/src/main/kotlin/com/defenseunicorns/koci/Scopes.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 Defense Unicorns
+ * Copyright 2024-2026 Defense Unicorns
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/src/test/kotlin/com/defenseunicorns/koci/LayoutTest.kt
+++ b/src/test/kotlin/com/defenseunicorns/koci/LayoutTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 Defense Unicorns
+ * Copyright 2024-2026 Defense Unicorns
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/src/test/kotlin/com/defenseunicorns/koci/ReferenceTest.kt
+++ b/src/test/kotlin/com/defenseunicorns/koci/ReferenceTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 Defense Unicorns
+ * Copyright 2024-2026 Defense Unicorns
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/src/test/kotlin/com/defenseunicorns/koci/RegistryTest.kt
+++ b/src/test/kotlin/com/defenseunicorns/koci/RegistryTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 Defense Unicorns
+ * Copyright 2024-2026 Defense Unicorns
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/src/test/kotlin/com/defenseunicorns/koci/RouteTest.kt
+++ b/src/test/kotlin/com/defenseunicorns/koci/RouteTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 Defense Unicorns
+ * Copyright 2024-2026 Defense Unicorns
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/src/test/kotlin/com/defenseunicorns/koci/ScopesTest.kt
+++ b/src/test/kotlin/com/defenseunicorns/koci/ScopesTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 Defense Unicorns
+ * Copyright 2024-2026 Defense Unicorns
  * SPDX-License-Identifier: Apache-2.0
  */
 


### PR DESCRIPTION
Workflows were only running on `main`. Since `v2` will eventually be merged into `main`, we want to run all workflows against it.
