### PR TITLE
fix: updated buffer to be consistent and added constants

### DIFF
--- a/src/main/kotlin/com/defenseunicorns/koci/Constants.kt
+++ b/src/main/kotlin/com/defenseunicorns/koci/Constants.kt
@@ -1,0 +1,10 @@
+/*
+ * Copyright 2026 Defense Unicorns
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.defenseunicorns.koci
+
+internal const val IO_BUFFER_SIZE = 32 * 1024 // 32 KB
+// TODO: Change this to an Int once later updates are made since Long is not needed @landon
+internal const val DEFAULT_UPLOAD_CHUNK_SIZE = 5L * 1024 * 1024 // 5 MB

--- a/src/main/kotlin/com/defenseunicorns/koci/DataClasses.kt
+++ b/src/main/kotlin/com/defenseunicorns/koci/DataClasses.kt
@@ -185,7 +185,7 @@ public data class Descriptor(
     ): Descriptor {
       val md = algorithm.hasher()
       var size = 0L
-      val buffer = ByteArray(1024)
+      val buffer = ByteArray(IO_BUFFER_SIZE)
       stream.use { s ->
         var bytesRead: Int
         while (s.read(buffer).also { bytesRead = it } != -1) {

--- a/src/main/kotlin/com/defenseunicorns/koci/Layout.kt
+++ b/src/main/kotlin/com/defenseunicorns/koci/Layout.kt
@@ -108,7 +108,7 @@ public class Layout private constructor(internal val index: Index, private val r
     val digest =
       withContext(Dispatchers.IO) {
         file.inputStream().use { s ->
-          val buffer = ByteArray(1024)
+          val buffer = ByteArray(IO_BUFFER_SIZE)
           val md = descriptor.digest.algorithm.hasher()
           var bytesRead: Int
           while (s.read(buffer).also { bytesRead = it } != -1) {
@@ -314,7 +314,7 @@ public class Layout private constructor(internal val index: Index, private val r
           if (fileExists) {
             withContext(Dispatchers.IO) {
               file.inputStream().use { fis ->
-                val buffer = ByteArray(32 * 1024)
+                val buffer = ByteArray(IO_BUFFER_SIZE)
                 var bytesRead: Int
                 while (fis.read(buffer).also { bytesRead = it } != -1) {
                   md.update(buffer, 0, bytesRead)
@@ -324,7 +324,7 @@ public class Layout private constructor(internal val index: Index, private val r
             }
           }
 
-          val buffer = ByteArray(4 * 1024)
+          val buffer = ByteArray(IO_BUFFER_SIZE)
           var bytesRead: Int
           withContext(Dispatchers.IO) {
             FileOutputStream(file, true).use { out ->

--- a/src/main/kotlin/com/defenseunicorns/koci/Repository.kt
+++ b/src/main/kotlin/com/defenseunicorns/koci/Repository.kt
@@ -586,7 +586,7 @@ public class Repository(
         val start = startOrResumeUpload(expected).also { uploading[expected] = it }
 
         if (start.minChunkSize == 0L) {
-          start.minChunkSize = 5 * 1024 * 1024
+          start.minChunkSize = DEFAULT_UPLOAD_CHUNK_SIZE
         }
 
         when (val bytesLeft = expected.size - start.offset) {

--- a/src/test/kotlin/com/defenseunicorns/koci/RegistryTest.kt
+++ b/src/test/kotlin/com/defenseunicorns/koci/RegistryTest.kt
@@ -531,7 +531,7 @@ class RegistryTest {
 
 fun generateRandomFile(filePath: String, sizeInBytes: Int): Descriptor {
   val random = Random.Default
-  val buffer = ByteArray(1024) // 1KB buffer
+  val buffer = ByteArray(IO_BUFFER_SIZE)
 
   FileOutputStream(File(filePath)).use { outputStream ->
     var bytesWritten = 0


### PR DESCRIPTION
Created a constant `IO_BUFFER_SIZE` that is `32 KB` large. Keeps consistency across buffer sizes now as well as brings us in line with `oras-go` who also uses `32 KB`  buffer sizes. It should reduce the system calls and chunking that is needed to move bytes around.

Also added a constant for the `DEFAULT_UPLOAD_CHUNK_SIZE`.

These changes affect how files are chunked prior to being written to disk. So the below bench marks are for `pulling`.

### v1

Size | oras-go mean | oras-go p95 | koci mean | koci p95 | How much slower?
-- | -- | -- | -- | -- | --
50mb | 445.0ms | 487.3ms | 533.3ms | 599.3ms | 1.2x slower
500mb | 4.12s | 4.26s | 4.39s | 5.16s | 1.1x slower

### v2

| Size           | oras-go mean   | oras-go p95    | koci mean      | koci p95       | How much slower? |
|----------------|----------------|----------------|----------------|----------------|----------------|
| 50mb           | 449.0ms        | 574.8ms        | 481.0ms        | 714.5ms        | 1.1x slower    |
| 500mb          | 4.16s          | 4.77s          | 3.95s          | 5.00s          | 1.1x faster    |

As we can see, there is a minimal speed up for `koci`.

Fixes MOBILE-122
