### PR TITLE
chore: update CODEOWNERS to uds-fleet and add SECURITY.md

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
-/* @defenseunicorns/uds-edge
+* @defenseunicorns/uds-fleet
 
 /CODEOWNERS @jeff-mccoy @daveworth
 /LICENSE @jeff-mccoy @austenbryan

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,7 @@
+# Security Policy
+
+This document outlines the security policy for koci, including how to report vulnerabilities.
+
+## Reporting a vulnerability
+
+Email `security [at] defenseunicorns.com` to report a vulnerability. If you are unable to disclose details via email, please let us know and we can coordinate alternate communications.


### PR DESCRIPTION
## Summary

- Updates `CODEOWNERS` to replace `@defenseunicorns/uds-edge` with `@defenseunicorns/uds-fleet` (the team with repo access) and fixes the glob pattern from `/*` (root files only) to `*` (full repo coverage)
- Adds `SECURITY.md` with vulnerability reporting contact (`security@defenseunicorns.com`) as required for public repositories per the Defense Unicorns GitHub Repository Structure standard (ALL-4)

## Test plan

- [ ] Confirm `uds-fleet` members are requested as reviewers on subsequent PRs
- [ ] Confirm GitHub displays the Security Policy link on the repo's Security tab after merge