### PR TITLE
fix!: name of registry preserves port if non-standard

### DIFF
--- a/koci/api/koci.api
+++ b/koci/api/koci.api
@@ -228,8 +228,6 @@ public final class com/defenseunicorns/koci/api/Platform$Companion {
 
 public final class com/defenseunicorns/koci/api/Reference {
 	public static final field Companion Lcom/defenseunicorns/koci/api/Reference$Companion;
-	public fun <init> (Lio/ktor/http/Url;Ljava/lang/String;Ljava/lang/String;)V
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
 	public final fun digest ()Lcom/defenseunicorns/koci/api/Digest;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getReference ()Ljava/lang/String;
@@ -243,6 +241,7 @@ public final class com/defenseunicorns/koci/api/Reference {
 }
 
 public final class com/defenseunicorns/koci/api/Reference$Companion {
+	public final fun from (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/defenseunicorns/koci/api/Reference;
 	public final fun parse (Ljava/lang/String;)Lcom/defenseunicorns/koci/api/Reference;
 }
 

--- a/koci/src/main/kotlin/com/defenseunicorns/koci/api/Reference.kt
+++ b/koci/src/main/kotlin/com/defenseunicorns/koci/api/Reference.kt
@@ -7,36 +7,18 @@ package com.defenseunicorns.koci.api
 
 import com.defenseunicorns.koci.internal.Regex.repositoryRegex
 import com.defenseunicorns.koci.internal.Regex.tagRegex
-import io.ktor.http.Url
-import io.ktor.http.hostWithPort
-import io.ktor.http.toURI
 import java.net.URI
 
 /**
  * A complete reference to an OCI artifact, made of a registry host (`registry.example.com:5000`), a
  * repository path (`library/ubuntu`), and either a tag or digest (`latest`, `sha256:abc…`).
  */
-public class Reference(
+public class Reference
+internal constructor(
   public val registry: String,
   public val repository: String,
   public val reference: String,
 ) {
-  /** Builds a [Reference] from a [Url], using its host and optional port as the registry. */
-  public constructor(
-    registry: Url,
-    repository: String,
-    reference: String,
-  ) : this(
-    registry =
-      registry.toURI().let { uri ->
-        when (uri.port) {
-          -1 -> registry.host
-          else -> registry.hostWithPort
-        }
-      },
-    repository = repository,
-    reference = reference,
-  )
 
   override fun equals(other: Any?): Boolean {
     if (this === other) return true
@@ -106,6 +88,23 @@ public class Reference(
   }
 
   public companion object {
+    /**
+     * Builds a [Reference] from a registry URL string, stripping default ports (80, 443) from the
+     * registry name.
+     */
+    public fun from(registry: String, repository: String, reference: String): Reference {
+      val uri = URI(registry)
+      val registryName =
+        @Suppress("detekt:MagicNumber")
+        when (uri.port) {
+          -1,
+          80,
+          443 -> uri.host
+          else -> "${uri.host}:${uri.port}"
+        }
+      return Reference(registryName, repository, reference)
+    }
+
     /**
      * Parses [artifact] in any of the canonical OCI reference forms. Returns `null` if the result
      * is not valid.

--- a/koci/src/main/kotlin/com/defenseunicorns/koci/api/Registry.kt
+++ b/koci/src/main/kotlin/com/defenseunicorns/koci/api/Registry.kt
@@ -18,6 +18,7 @@ import io.ktor.client.call.body
 import io.ktor.client.request.url
 import io.ktor.http.HttpHeaders
 import io.ktor.http.Url
+import io.ktor.http.hostWithPort
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.serialization.json.Json
@@ -38,7 +39,7 @@ internal constructor(
   internal val json: Json,
   private val logger: KociLogger,
 ) {
-  public val name: String = Url(url).host
+  public val name: String = Url(url).hostWithPort
 
   /** Returns a [Repository] bound to [name] within this registry, e.g. `"myorg/myimage"`. */
   public fun repo(name: String): Repository =

--- a/koci/src/main/kotlin/com/defenseunicorns/koci/api/Registry.kt
+++ b/koci/src/main/kotlin/com/defenseunicorns/koci/api/Registry.kt
@@ -39,7 +39,7 @@ internal constructor(
   internal val json: Json,
   private val logger: KociLogger,
 ) {
-  public val name: String = Url(url).hostWithPort
+  public val name: String = Url(url).hostWithPort.replace(Regex(":(80|443)$"), "")
 
   /** Returns a [Repository] bound to [name] within this registry, e.g. `"myorg/myimage"`. */
   public fun repo(name: String): Repository =

--- a/koci/src/main/kotlin/com/defenseunicorns/koci/internal/RepositoryPuller.kt
+++ b/koci/src/main/kotlin/com/defenseunicorns/koci/internal/RepositoryPuller.kt
@@ -151,7 +151,8 @@ internal class RepositoryPuller(
           return@flow
         }
 
-        val ref = Reference(registry = router.base(), repository = name, reference = tag)
+        val ref =
+          Reference.from(registry = router.base().toString(), repository = name, reference = tag)
         when (store.inspect(manifest)) {
           is BlobState.Present -> {
             store.tag(manifest, ref)

--- a/koci/src/main/kotlin/com/defenseunicorns/koci/internal/RepositoryPusher.kt
+++ b/koci/src/main/kotlin/com/defenseunicorns/koci/internal/RepositoryPusher.kt
@@ -230,7 +230,10 @@ internal class RepositoryPusher(
 
         if (tag != null) {
           val root = walk.containers.last().first
-          store.tag(root, Reference(registry = router.base(), repository = name, reference = tag))
+          store.tag(
+            root,
+            Reference.from(registry = router.base().toString(), repository = name, reference = tag),
+          )
         }
 
         tracker.close()

--- a/koci/src/test/kotlin/com/defenseunicorns/koci/ReferenceTest.kt
+++ b/koci/src/test/kotlin/com/defenseunicorns/koci/ReferenceTest.kt
@@ -6,7 +6,6 @@
 package com.defenseunicorns.koci
 
 import com.defenseunicorns.koci.api.Reference
-import io.ktor.http.Url
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -67,9 +66,17 @@ class ReferenceTest {
       }
     }
 
-    val urlTestCase = Reference(Url("https://localhost:5005"), "repo", "tag")
+    val fromWithPort = Reference.from("https://localhost:5005", "repo", "tag")
+    assertEquals("localhost:5005/repo:tag", fromWithPort.toString())
 
-    assertEquals("localhost:5005/repo:tag", urlTestCase.toString())
+    val fromStripsPort443 = Reference.from("https://registry.example.com:443", "repo", "tag")
+    assertEquals("registry.example.com/repo:tag", fromStripsPort443.toString())
+
+    val fromStripsPort80 = Reference.from("http://registry.example.com:80", "repo", "tag")
+    assertEquals("registry.example.com/repo:tag", fromStripsPort80.toString())
+
+    val fromNoPort = Reference.from("https://registry.example.com", "repo", "tag")
+    assertEquals("registry.example.com/repo:tag", fromNoPort.toString())
 
     assertTrue(Reference("", "", "").isEmpty())
     assertFalse(Reference("", "", "").isNotEmpty())

--- a/koci/src/test/kotlin/com/defenseunicorns/koci/RegistryTest.kt
+++ b/koci/src/test/kotlin/com/defenseunicorns/koci/RegistryTest.kt
@@ -23,6 +23,31 @@ import kotlinx.coroutines.test.runTest
 class RegistryTest {
 
   @Test
+  fun `name strips default port 443`() {
+    val registry = fakeRegistry(url = "https://registry.example.com:443", handler = { respondOk() })
+    assertEquals("registry.example.com", registry.name)
+  }
+
+  @Test
+  fun `name strips default port 80`() {
+    val registry = fakeRegistry(url = "http://registry.example.com:80", handler = { respondOk() })
+    assertEquals("registry.example.com", registry.name)
+  }
+
+  @Test
+  fun `name preserves non-default port`() {
+    val registry =
+      fakeRegistry(url = "https://registry.example.com:5000", handler = { respondOk() })
+    assertEquals("registry.example.com:5000", registry.name)
+  }
+
+  @Test
+  fun `name without explicit port is unchanged`() {
+    val registry = fakeRegistry(handler = { respondOk() })
+    assertEquals("registry.example.com", registry.name)
+  }
+
+  @Test
   fun `repo returns repository with the given name`() {
     val registry = fakeRegistry(handler = { respondOk() })
     assertEquals("library/ubuntu", registry.repo("library/ubuntu").name)


### PR DESCRIPTION
From v1 to v2 we attempted to strip a bunch of unneeded things such as exposing the `Router`, since it is an internal implementation. Since that was internalized, we exposed a `name` off the `Registry` class.

However this was missing the port if it was non-standard. So if the registry was at `localhost:5000` it would show as `localhost`. We added that back. But there was a deeper problem. The `Reference` constructor was expecting a `String` or a secondary was expecting a ktor `URL`. Since we dropped the `router` and tried to use either the `url` or `name` on the `Registry`, references would not line up with `v1` references.

The fix was to internalize the constructor and expose a `from` function to take in a `String` url and determine how to construct the `Reference`. We also dropped the exposure of the ktor `URL` type so that consumers don't need to pull the library in.