### PR TITLE
fix: non scheme breaking reference func

### DIFF
--- a/koci/src/main/kotlin/com/defenseunicorns/koci/api/Reference.kt
+++ b/koci/src/main/kotlin/com/defenseunicorns/koci/api/Reference.kt
@@ -93,13 +93,19 @@ internal constructor(
      * registry name.
      */
     public fun from(registry: String, repository: String, reference: String): Reference {
-      val uri = URI(registry)
+      val normalized =
+        when ("://" in registry) {
+          true -> registry
+          false -> "dummy://$registry"
+        }
+      val uri = URI(normalized)
       val registryName =
         @Suppress("detekt:MagicNumber")
         when (uri.port) {
           -1,
           80,
           443 -> uri.host
+
           else -> "${uri.host}:${uri.port}"
         }
       return Reference(registryName, repository, reference)

--- a/koci/src/test/kotlin/com/defenseunicorns/koci/ReferenceTest.kt
+++ b/koci/src/test/kotlin/com/defenseunicorns/koci/ReferenceTest.kt
@@ -78,6 +78,9 @@ class ReferenceTest {
     val fromNoPort = Reference.from("https://registry.example.com", "repo", "tag")
     assertEquals("registry.example.com/repo:tag", fromNoPort.toString())
 
+    val fromBareHostPort = Reference.from("10.0.2.2:5000", "repo", "tag")
+    assertEquals("10.0.2.2:5000/repo:tag", fromBareHostPort.toString())
+
     assertTrue(Reference("", "", "").isEmpty())
     assertFalse(Reference("", "", "").isNotEmpty())
     val partialEmpties =


### PR DESCRIPTION
`10.0.2.2:5000` was breaking the `from` function. This fixes it and adds a test.
