### PR TITLE
feat!: add docker oci manifest support

### DIFF
--- a/koci/api/koci.api
+++ b/koci/api/koci.api
@@ -191,19 +191,19 @@ public final class com/defenseunicorns/koci/api/Manifest$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public final class com/defenseunicorns/koci/api/OciConstants : java/lang/Enum {
-	public static final field Companion Lcom/defenseunicorns/koci/api/OciConstants$Companion;
-	public static final field DOCKER_MANIFEST Lcom/defenseunicorns/koci/api/OciConstants;
-	public static final field INDEX Lcom/defenseunicorns/koci/api/OciConstants;
-	public static final field MANIFEST Lcom/defenseunicorns/koci/api/OciConstants;
+public final class com/defenseunicorns/koci/api/ManifestConstants : java/lang/Enum {
+	public static final field Companion Lcom/defenseunicorns/koci/api/ManifestConstants$Companion;
+	public static final field DOCKER Lcom/defenseunicorns/koci/api/ManifestConstants;
+	public static final field INDEX Lcom/defenseunicorns/koci/api/ManifestConstants;
+	public static final field OCI Lcom/defenseunicorns/koci/api/ManifestConstants;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun getMediaType ()Ljava/lang/String;
-	public static fun valueOf (Ljava/lang/String;)Lcom/defenseunicorns/koci/api/OciConstants;
-	public static fun values ()[Lcom/defenseunicorns/koci/api/OciConstants;
+	public static fun valueOf (Ljava/lang/String;)Lcom/defenseunicorns/koci/api/ManifestConstants;
+	public static fun values ()[Lcom/defenseunicorns/koci/api/ManifestConstants;
 }
 
-public final class com/defenseunicorns/koci/api/OciConstants$Companion {
-	public final fun fromMediaType (Ljava/lang/String;)Lcom/defenseunicorns/koci/api/OciConstants;
+public final class com/defenseunicorns/koci/api/ManifestConstants$Companion {
+	public final fun fromMediaType (Ljava/lang/String;)Lcom/defenseunicorns/koci/api/ManifestConstants;
 }
 
 public final class com/defenseunicorns/koci/api/Platform {

--- a/koci/api/koci.api
+++ b/koci/api/koci.api
@@ -191,10 +191,19 @@ public final class com/defenseunicorns/koci/api/Manifest$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public final class com/defenseunicorns/koci/api/OciConstants {
-	public static final field INDEX_MEDIA_TYPE Ljava/lang/String;
-	public static final field INSTANCE Lcom/defenseunicorns/koci/api/OciConstants;
-	public static final field MANIFEST_MEDIA_TYPE Ljava/lang/String;
+public final class com/defenseunicorns/koci/api/OciConstants : java/lang/Enum {
+	public static final field Companion Lcom/defenseunicorns/koci/api/OciConstants$Companion;
+	public static final field DOCKER_MANIFEST Lcom/defenseunicorns/koci/api/OciConstants;
+	public static final field INDEX Lcom/defenseunicorns/koci/api/OciConstants;
+	public static final field MANIFEST Lcom/defenseunicorns/koci/api/OciConstants;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun getMediaType ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lcom/defenseunicorns/koci/api/OciConstants;
+	public static fun values ()[Lcom/defenseunicorns/koci/api/OciConstants;
+}
+
+public final class com/defenseunicorns/koci/api/OciConstants$Companion {
+	public final fun fromMediaType (Ljava/lang/String;)Lcom/defenseunicorns/koci/api/OciConstants;
 }
 
 public final class com/defenseunicorns/koci/api/Platform {

--- a/koci/src/main/kotlin/com/defenseunicorns/koci/api/Layout.kt
+++ b/koci/src/main/kotlin/com/defenseunicorns/koci/api/Layout.kt
@@ -319,7 +319,7 @@ internal constructor(
         }
 
         when (descriptor.mediaType) {
-          OciConstants.INDEX_MEDIA_TYPE -> {
+          OciConstants.INDEX.mediaType -> {
             val indexToRemove: Index =
               fileSystem.source(blobPath).buffer().use { source ->
                 json.decodeFromString(source.readUtf8())
@@ -338,7 +338,7 @@ internal constructor(
             true
           }
 
-          OciConstants.MANIFEST_MEDIA_TYPE -> {
+          OciConstants.MANIFEST.mediaType -> {
             val otherManifests =
               indexMutex.withLock {
                 val others = index.manifests.filter { it.digest != descriptor.digest }
@@ -458,7 +458,7 @@ internal constructor(
       .flatMap { desc ->
         val path = blobPath(desc)
         when (desc.mediaType) {
-          OciConstants.INDEX_MEDIA_TYPE -> {
+          OciConstants.INDEX.mediaType -> {
             if (path != null && fileSystem.exists(path)) {
               val i: Index =
                 fileSystem.source(path).buffer().use { source ->
@@ -470,7 +470,7 @@ internal constructor(
             }
           }
 
-          OciConstants.MANIFEST_MEDIA_TYPE -> {
+          OciConstants.MANIFEST.mediaType -> {
             if (path != null && fileSystem.exists(path)) {
               val m: Manifest =
                 fileSystem.source(path).buffer().use { source ->

--- a/koci/src/main/kotlin/com/defenseunicorns/koci/api/Layout.kt
+++ b/koci/src/main/kotlin/com/defenseunicorns/koci/api/Layout.kt
@@ -319,7 +319,7 @@ internal constructor(
         }
 
         when (descriptor.mediaType) {
-          OciConstants.INDEX.mediaType -> {
+          ManifestConstants.INDEX.mediaType -> {
             val indexToRemove: Index =
               fileSystem.source(blobPath).buffer().use { source ->
                 json.decodeFromString(source.readUtf8())
@@ -338,7 +338,7 @@ internal constructor(
             true
           }
 
-          OciConstants.MANIFEST.mediaType -> {
+          ManifestConstants.OCI.mediaType -> {
             val otherManifests =
               indexMutex.withLock {
                 val others = index.manifests.filter { it.digest != descriptor.digest }
@@ -458,7 +458,7 @@ internal constructor(
       .flatMap { desc ->
         val path = blobPath(desc)
         when (desc.mediaType) {
-          OciConstants.INDEX.mediaType -> {
+          ManifestConstants.INDEX.mediaType -> {
             if (path != null && fileSystem.exists(path)) {
               val i: Index =
                 fileSystem.source(path).buffer().use { source ->
@@ -470,7 +470,7 @@ internal constructor(
             }
           }
 
-          OciConstants.MANIFEST.mediaType -> {
+          ManifestConstants.OCI.mediaType -> {
             if (path != null && fileSystem.exists(path)) {
               val m: Manifest =
                 fileSystem.source(path).buffer().use { source ->

--- a/koci/src/main/kotlin/com/defenseunicorns/koci/api/ManifestConstants.kt
+++ b/koci/src/main/kotlin/com/defenseunicorns/koci/api/ManifestConstants.kt
@@ -5,18 +5,18 @@
 
 package com.defenseunicorns.koci.api
 
-public enum class OciConstants(public val mediaType: String) {
+public enum class ManifestConstants(public val mediaType: String) {
   /** Media type for an image manifest (see [Manifest]). */
-  MANIFEST("application/vnd.oci.image.manifest.v1+json"),
+  OCI("application/vnd.oci.image.manifest.v1+json"),
 
   /** Media type for a Docker manifest. */
-  DOCKER_MANIFEST("application/vnd.docker.distribution.manifest.v2+json"),
+  DOCKER("application/vnd.docker.distribution.manifest.v2+json"),
 
   /** Media type for an image index (see [Index]). */
   INDEX("application/vnd.oci.image.index.v1+json");
 
   public companion object {
-    public fun fromMediaType(mediaType: String?): OciConstants? =
+    public fun fromMediaType(mediaType: String?): ManifestConstants? =
       entries.firstOrNull { it.mediaType == mediaType }
   }
 }

--- a/koci/src/main/kotlin/com/defenseunicorns/koci/api/OciConstants.kt
+++ b/koci/src/main/kotlin/com/defenseunicorns/koci/api/OciConstants.kt
@@ -5,11 +5,18 @@
 
 package com.defenseunicorns.koci.api
 
-public object OciConstants {
-
+public enum class OciConstants(public val mediaType: String) {
   /** Media type for an image manifest (see [Manifest]). */
-  public const val MANIFEST_MEDIA_TYPE: String = "application/vnd.oci.image.manifest.v1+json"
+  MANIFEST("application/vnd.oci.image.manifest.v1+json"),
+
+  /** Media type for a Docker manifest. */
+  DOCKER_MANIFEST("application/vnd.docker.distribution.manifest.v2+json"),
 
   /** Media type for an image index (see [Index]). */
-  public const val INDEX_MEDIA_TYPE: String = "application/vnd.oci.image.index.v1+json"
+  INDEX("application/vnd.oci.image.index.v1+json");
+
+  public companion object {
+    public fun fromMediaType(mediaType: String?): OciConstants? =
+      entries.firstOrNull { it.mediaType == mediaType }
+  }
 }

--- a/koci/src/main/kotlin/com/defenseunicorns/koci/internal/RepositoryPuller.kt
+++ b/koci/src/main/kotlin/com/defenseunicorns/koci/internal/RepositoryPuller.kt
@@ -9,8 +9,7 @@ import com.defenseunicorns.koci.api.Descriptor
 import com.defenseunicorns.koci.api.Digest
 import com.defenseunicorns.koci.api.Index
 import com.defenseunicorns.koci.api.Layout
-import com.defenseunicorns.koci.api.OciConstants.INDEX_MEDIA_TYPE
-import com.defenseunicorns.koci.api.OciConstants.MANIFEST_MEDIA_TYPE
+import com.defenseunicorns.koci.api.OciConstants
 import com.defenseunicorns.koci.api.Platform
 import com.defenseunicorns.koci.api.Reference
 import com.defenseunicorns.koci.api.TransferEvent
@@ -113,18 +112,19 @@ internal class RepositoryPuller(
       buildRequest = {
         method = HttpMethod.Get
         url(endpoint)
-        accept(ContentType.parse(MANIFEST_MEDIA_TYPE))
-        accept(ContentType.parse(INDEX_MEDIA_TYPE))
+        acceptContainerTypes()
         attributes.appendScopes(scopeRepository(name, ACTION_PULL))
       },
       onSuccess = { res ->
         when (val ct = res.contentType()?.toString()) {
-          MANIFEST_MEDIA_TYPE -> manifestDescriptor(res, endpoint, MANIFEST_MEDIA_TYPE)
-          INDEX_MEDIA_TYPE ->
+          OciConstants.MANIFEST.mediaType,
+          OciConstants.DOCKER_MANIFEST.mediaType -> manifestDescriptor(res, endpoint, ct)
+          OciConstants.INDEX.mediaType ->
             when (platformResolver) {
-              null -> manifestDescriptor(res, endpoint, INDEX_MEDIA_TYPE)
+              null -> manifestDescriptor(res, endpoint, OciConstants.INDEX.mediaType)
               else -> selectPlatform(res.body<Index>(), platformResolver)
             }
+
           else -> {
             logger.warn { "unsupported manifest content type from $endpoint: $ct" }
             null
@@ -377,17 +377,22 @@ internal class RepositoryPuller(
    */
   private fun endpointFor(descriptor: Descriptor): Url? =
     when (descriptor.mediaType) {
-      MANIFEST_MEDIA_TYPE,
-      INDEX_MEDIA_TYPE -> router.manifest(name, descriptor)
+      OciConstants.MANIFEST.mediaType,
+      OciConstants.DOCKER_MANIFEST.mediaType,
+      OciConstants.INDEX.mediaType -> router.manifest(name, descriptor)
 
       else -> router.blob(name, descriptor)
     }
 
+  /** Adds every manifest/index `Accept` header used when resolving by tag. */
+  private fun HttpRequestBuilder.acceptContainerTypes() {
+    OciConstants.entries.forEach { constant -> accept(ContentType.parse(constant.mediaType)) }
+  }
+
   /** Adds the right `Accept` header for manifest or index descriptors. No-op for blobs. */
   private fun HttpRequestBuilder.acceptForDescriptor(descriptor: Descriptor) {
-    when (descriptor.mediaType) {
-      MANIFEST_MEDIA_TYPE -> accept(ContentType.parse(MANIFEST_MEDIA_TYPE))
-      INDEX_MEDIA_TYPE -> accept(ContentType.parse(INDEX_MEDIA_TYPE))
+    if (OciConstants.fromMediaType(descriptor.mediaType) != null) {
+      accept(ContentType.parse(descriptor.mediaType))
     }
   }
 

--- a/koci/src/main/kotlin/com/defenseunicorns/koci/internal/RepositoryPuller.kt
+++ b/koci/src/main/kotlin/com/defenseunicorns/koci/internal/RepositoryPuller.kt
@@ -9,7 +9,7 @@ import com.defenseunicorns.koci.api.Descriptor
 import com.defenseunicorns.koci.api.Digest
 import com.defenseunicorns.koci.api.Index
 import com.defenseunicorns.koci.api.Layout
-import com.defenseunicorns.koci.api.OciConstants
+import com.defenseunicorns.koci.api.ManifestConstants
 import com.defenseunicorns.koci.api.Platform
 import com.defenseunicorns.koci.api.Reference
 import com.defenseunicorns.koci.api.TransferEvent
@@ -117,11 +117,11 @@ internal class RepositoryPuller(
       },
       onSuccess = { res ->
         when (val ct = res.contentType()?.toString()) {
-          OciConstants.MANIFEST.mediaType,
-          OciConstants.DOCKER_MANIFEST.mediaType -> manifestDescriptor(res, endpoint, ct)
-          OciConstants.INDEX.mediaType ->
+          ManifestConstants.OCI.mediaType,
+          ManifestConstants.DOCKER.mediaType -> manifestDescriptor(res, endpoint, ct)
+          ManifestConstants.INDEX.mediaType ->
             when (platformResolver) {
-              null -> manifestDescriptor(res, endpoint, OciConstants.INDEX.mediaType)
+              null -> manifestDescriptor(res, endpoint, ManifestConstants.INDEX.mediaType)
               else -> selectPlatform(res.body<Index>(), platformResolver)
             }
 
@@ -377,21 +377,21 @@ internal class RepositoryPuller(
    */
   private fun endpointFor(descriptor: Descriptor): Url? =
     when (descriptor.mediaType) {
-      OciConstants.MANIFEST.mediaType,
-      OciConstants.DOCKER_MANIFEST.mediaType,
-      OciConstants.INDEX.mediaType -> router.manifest(name, descriptor)
+      ManifestConstants.OCI.mediaType,
+      ManifestConstants.DOCKER.mediaType,
+      ManifestConstants.INDEX.mediaType -> router.manifest(name, descriptor)
 
       else -> router.blob(name, descriptor)
     }
 
   /** Adds every manifest/index `Accept` header used when resolving by tag. */
   private fun HttpRequestBuilder.acceptContainerTypes() {
-    OciConstants.entries.forEach { constant -> accept(ContentType.parse(constant.mediaType)) }
+    ManifestConstants.entries.forEach { constant -> accept(ContentType.parse(constant.mediaType)) }
   }
 
   /** Adds the right `Accept` header for manifest or index descriptors. No-op for blobs. */
   private fun HttpRequestBuilder.acceptForDescriptor(descriptor: Descriptor) {
-    if (OciConstants.fromMediaType(descriptor.mediaType) != null) {
+    if (ManifestConstants.fromMediaType(descriptor.mediaType) != null) {
       accept(ContentType.parse(descriptor.mediaType))
     }
   }

--- a/koci/src/main/kotlin/com/defenseunicorns/koci/internal/RepositoryPusher.kt
+++ b/koci/src/main/kotlin/com/defenseunicorns/koci/internal/RepositoryPusher.kt
@@ -10,8 +10,7 @@ import com.defenseunicorns.koci.api.Digest
 import com.defenseunicorns.koci.api.Index
 import com.defenseunicorns.koci.api.Layout
 import com.defenseunicorns.koci.api.Manifest
-import com.defenseunicorns.koci.api.OciConstants.INDEX_MEDIA_TYPE
-import com.defenseunicorns.koci.api.OciConstants.MANIFEST_MEDIA_TYPE
+import com.defenseunicorns.koci.api.OciConstants
 import com.defenseunicorns.koci.api.Reference
 import com.defenseunicorns.koci.api.RegisteredAlgorithm
 import com.defenseunicorns.koci.api.TransferEvent
@@ -130,7 +129,11 @@ internal class RepositoryPusher(
    *   Distribution Spec: Pushing Manifests</a>
    */
   suspend fun tag(content: Manifest, ref: String): Descriptor? =
-    tagContent(ref, content.mediaType ?: MANIFEST_MEDIA_TYPE, json.encodeToString(content))
+    tagContent(
+      ref,
+      content.mediaType ?: OciConstants.MANIFEST.mediaType,
+      json.encodeToString(content),
+    )
 
   /**
    * Tags an [Index] under [ref].
@@ -140,7 +143,7 @@ internal class RepositoryPusher(
    *   Distribution Spec: Pushing Manifests</a>
    */
   suspend fun tag(content: Index, ref: String): Descriptor? =
-    tagContent(ref, content.mediaType ?: INDEX_MEDIA_TYPE, json.encodeToString(content))
+    tagContent(ref, content.mediaType ?: OciConstants.INDEX.mediaType, json.encodeToString(content))
 
   private suspend fun tagContent(ref: String, mediaType: String, body: String): Descriptor? {
     if (tagRegex.matchEntire(ref) == null) return null

--- a/koci/src/main/kotlin/com/defenseunicorns/koci/internal/RepositoryPusher.kt
+++ b/koci/src/main/kotlin/com/defenseunicorns/koci/internal/RepositoryPusher.kt
@@ -10,7 +10,7 @@ import com.defenseunicorns.koci.api.Digest
 import com.defenseunicorns.koci.api.Index
 import com.defenseunicorns.koci.api.Layout
 import com.defenseunicorns.koci.api.Manifest
-import com.defenseunicorns.koci.api.OciConstants
+import com.defenseunicorns.koci.api.ManifestConstants
 import com.defenseunicorns.koci.api.Reference
 import com.defenseunicorns.koci.api.RegisteredAlgorithm
 import com.defenseunicorns.koci.api.TransferEvent
@@ -131,7 +131,7 @@ internal class RepositoryPusher(
   suspend fun tag(content: Manifest, ref: String): Descriptor? =
     tagContent(
       ref,
-      content.mediaType ?: OciConstants.MANIFEST.mediaType,
+      content.mediaType ?: ManifestConstants.OCI.mediaType,
       json.encodeToString(content),
     )
 
@@ -143,7 +143,11 @@ internal class RepositoryPusher(
    *   Distribution Spec: Pushing Manifests</a>
    */
   suspend fun tag(content: Index, ref: String): Descriptor? =
-    tagContent(ref, content.mediaType ?: OciConstants.INDEX.mediaType, json.encodeToString(content))
+    tagContent(
+      ref,
+      content.mediaType ?: ManifestConstants.INDEX.mediaType,
+      json.encodeToString(content),
+    )
 
   private suspend fun tagContent(ref: String, mediaType: String, body: String): Descriptor? {
     if (tagRegex.matchEntire(ref) == null) return null

--- a/koci/src/main/kotlin/com/defenseunicorns/koci/internal/TreeWalk.kt
+++ b/koci/src/main/kotlin/com/defenseunicorns/koci/internal/TreeWalk.kt
@@ -8,7 +8,7 @@ package com.defenseunicorns.koci.internal
 import com.defenseunicorns.koci.api.Descriptor
 import com.defenseunicorns.koci.api.Index
 import com.defenseunicorns.koci.api.Manifest
-import com.defenseunicorns.koci.api.OciConstants
+import com.defenseunicorns.koci.api.ManifestConstants
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.flatMapMerge
@@ -50,9 +50,9 @@ internal suspend fun walkTree(
   while (queue.isNotEmpty()) {
     val d = queue.removeFirst()
     when (d.mediaType) {
-      OciConstants.MANIFEST.mediaType,
-      OciConstants.DOCKER_MANIFEST.mediaType,
-      OciConstants.INDEX.mediaType -> {
+      ManifestConstants.OCI.mediaType,
+      ManifestConstants.DOCKER.mediaType,
+      ManifestConstants.INDEX.mediaType -> {
         val buffer = fetchContainer(d) ?: return null
         val children = parseChildren(d, buffer, json, logger) ?: return null
         containers += d to buffer
@@ -98,12 +98,12 @@ private fun parseChildren(
 ): List<Descriptor>? =
   try {
     when (descriptor.mediaType) {
-      OciConstants.MANIFEST.mediaType,
-      OciConstants.DOCKER_MANIFEST.mediaType -> {
+      ManifestConstants.OCI.mediaType,
+      ManifestConstants.DOCKER.mediaType -> {
         val m = json.decodeFromString<Manifest>(buffer.peek().readUtf8())
         m.layers + m.config
       }
-      OciConstants.INDEX.mediaType ->
+      ManifestConstants.INDEX.mediaType ->
         json.decodeFromString<Index>(buffer.peek().readUtf8()).manifests
       else -> emptyList()
     }

--- a/koci/src/main/kotlin/com/defenseunicorns/koci/internal/TreeWalk.kt
+++ b/koci/src/main/kotlin/com/defenseunicorns/koci/internal/TreeWalk.kt
@@ -8,8 +8,7 @@ package com.defenseunicorns.koci.internal
 import com.defenseunicorns.koci.api.Descriptor
 import com.defenseunicorns.koci.api.Index
 import com.defenseunicorns.koci.api.Manifest
-import com.defenseunicorns.koci.api.OciConstants.INDEX_MEDIA_TYPE
-import com.defenseunicorns.koci.api.OciConstants.MANIFEST_MEDIA_TYPE
+import com.defenseunicorns.koci.api.OciConstants
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.flatMapMerge
@@ -51,8 +50,9 @@ internal suspend fun walkTree(
   while (queue.isNotEmpty()) {
     val d = queue.removeFirst()
     when (d.mediaType) {
-      MANIFEST_MEDIA_TYPE,
-      INDEX_MEDIA_TYPE -> {
+      OciConstants.MANIFEST.mediaType,
+      OciConstants.DOCKER_MANIFEST.mediaType,
+      OciConstants.INDEX.mediaType -> {
         val buffer = fetchContainer(d) ?: return null
         val children = parseChildren(d, buffer, json, logger) ?: return null
         containers += d to buffer
@@ -98,11 +98,13 @@ private fun parseChildren(
 ): List<Descriptor>? =
   try {
     when (descriptor.mediaType) {
-      MANIFEST_MEDIA_TYPE -> {
+      OciConstants.MANIFEST.mediaType,
+      OciConstants.DOCKER_MANIFEST.mediaType -> {
         val m = json.decodeFromString<Manifest>(buffer.peek().readUtf8())
         m.layers + m.config
       }
-      INDEX_MEDIA_TYPE -> json.decodeFromString<Index>(buffer.peek().readUtf8()).manifests
+      OciConstants.INDEX.mediaType ->
+        json.decodeFromString<Index>(buffer.peek().readUtf8()).manifests
       else -> emptyList()
     }
   } catch (e: Exception) {

--- a/koci/src/test/kotlin/com/defenseunicorns/koci/LayoutTest.kt
+++ b/koci/src/test/kotlin/com/defenseunicorns/koci/LayoutTest.kt
@@ -11,7 +11,7 @@ import com.defenseunicorns.koci.TestFixtures.testJson
 import com.defenseunicorns.koci.TestFixtures.writeBlob
 import com.defenseunicorns.koci.api.Descriptor
 import com.defenseunicorns.koci.api.Manifest
-import com.defenseunicorns.koci.api.OciConstants
+import com.defenseunicorns.koci.api.ManifestConstants
 import com.defenseunicorns.koci.api.Platform
 import com.defenseunicorns.koci.api.Reference
 import kotlin.test.Test
@@ -39,7 +39,7 @@ class LayoutTest {
     val layout = buildLayout()
     repeat(3) { i ->
       val bytes = "content-$i".toByteArray()
-      val desc = layout.writeBlob(bytes, OciConstants.MANIFEST.mediaType)
+      val desc = layout.writeBlob(bytes, ManifestConstants.OCI.mediaType)
       val ref = Reference("registry.example.com", "repo", "tag-$i")
       layout.tag(desc, ref)
     }
@@ -82,7 +82,7 @@ class LayoutTest {
   @Test
   fun `resolveDescriptor returns null when predicate never matches`() = runTest {
     val layout = buildLayout()
-    val desc = layout.writeBlob("x".toByteArray(), OciConstants.MANIFEST.mediaType)
+    val desc = layout.writeBlob("x".toByteArray(), ManifestConstants.OCI.mediaType)
     layout.tag(desc, Reference("r.example.com", "repo", "v1"))
     assertNull(layout.resolveDescriptor { it.mediaType == "no/match" })
   }
@@ -90,8 +90,8 @@ class LayoutTest {
   @Test
   fun `resolveDescriptor returns first descriptor satisfying predicate`() = runTest {
     val layout = buildLayout()
-    val descA = layout.writeBlob("a".toByteArray(), OciConstants.MANIFEST.mediaType)
-    val descB = layout.writeBlob("b".toByteArray(), OciConstants.MANIFEST.mediaType)
+    val descA = layout.writeBlob("a".toByteArray(), ManifestConstants.OCI.mediaType)
+    val descB = layout.writeBlob("b".toByteArray(), ManifestConstants.OCI.mediaType)
     layout.tag(descA, Reference("r.example.com", "repo", "tag-a"))
     layout.tag(descB, Reference("r.example.com", "repo", "tag-b"))
     val found = layout.resolveDescriptor { it.digest == descA.digest }
@@ -109,7 +109,7 @@ class LayoutTest {
   @Test
   fun `resolveReference returns descriptor for its tagged reference`() = runTest {
     val layout = buildLayout()
-    val desc = layout.writeBlob("manifest".toByteArray(), OciConstants.MANIFEST.mediaType)
+    val desc = layout.writeBlob("manifest".toByteArray(), ManifestConstants.OCI.mediaType)
     val ref = Reference("r.example.com", "repo", "latest")
     layout.tag(desc, ref)
     val resolved = layout.resolveReference(ref)
@@ -124,11 +124,11 @@ class LayoutTest {
     val arm64Bytes = "arm64-manifest".toByteArray()
     val amd64 =
       layout
-        .writeBlob(amd64Bytes, OciConstants.MANIFEST.mediaType)
+        .writeBlob(amd64Bytes, ManifestConstants.OCI.mediaType)
         .copy(platform = Platform(architecture = "amd64", os = "linux"))
     val arm64 =
       layout
-        .writeBlob(arm64Bytes, OciConstants.MANIFEST.mediaType)
+        .writeBlob(arm64Bytes, ManifestConstants.OCI.mediaType)
         .copy(platform = Platform(architecture = "arm64", os = "linux"))
     val ref = Reference("r.example.com", "repo", "latest")
     layout.tag(amd64, ref)
@@ -142,7 +142,7 @@ class LayoutTest {
   @Test
   fun `tag makes descriptor findable by reference`() = runTest {
     val layout = buildLayout()
-    val desc = layout.writeBlob("m".toByteArray(), OciConstants.MANIFEST.mediaType)
+    val desc = layout.writeBlob("m".toByteArray(), ManifestConstants.OCI.mediaType)
     val ref = Reference("r.example.com", "repo", "v2")
     layout.tag(desc, ref)
     assertNotNull(layout.resolveReference(ref))
@@ -152,8 +152,8 @@ class LayoutTest {
   fun `tag replaces existing entry for the same reference`() = runTest {
     val layout = buildLayout()
     val ref = Reference("r.example.com", "repo", "stable")
-    val old = layout.writeBlob("old".toByteArray(), OciConstants.MANIFEST.mediaType)
-    val new = layout.writeBlob("new".toByteArray(), OciConstants.MANIFEST.mediaType)
+    val old = layout.writeBlob("old".toByteArray(), ManifestConstants.OCI.mediaType)
+    val new = layout.writeBlob("new".toByteArray(), ManifestConstants.OCI.mediaType)
     layout.tag(old, ref)
     layout.tag(new, ref)
     assertEquals(1, layout.catalog().size)
@@ -175,9 +175,9 @@ class LayoutTest {
       layout.writeBlob("{}".toByteArray(), "application/vnd.oci.image.config.v1+json")
     val manifestBytes =
       testJson.encodeToString(Manifest(config = configDesc, layers = emptyList())).toByteArray()
-    val manifestDesc = layout.writeBlob(manifestBytes, OciConstants.MANIFEST.mediaType)
+    val ociManifestDesc = layout.writeBlob(manifestBytes, ManifestConstants.OCI.mediaType)
     val ref = Reference("r.example.com", "repo", "v1")
-    layout.tag(manifestDesc, ref)
+    layout.tag(ociManifestDesc, ref)
     layout.remove(ref)
     assertEquals(emptyList(), layout.catalog())
   }
@@ -202,13 +202,13 @@ class LayoutTest {
       testJson
         .encodeToString(Manifest(config = configBDesc, layers = listOf(layerDesc)))
         .toByteArray()
-    val manifestADesc = layout.writeBlob(manifestABytes, OciConstants.MANIFEST.mediaType)
-    val manifestBDesc = layout.writeBlob(manifestBBytes, OciConstants.MANIFEST.mediaType)
+    val ociManifestADesc = layout.writeBlob(manifestABytes, ManifestConstants.OCI.mediaType)
+    val ociManifestBDesc = layout.writeBlob(manifestBBytes, ManifestConstants.OCI.mediaType)
 
-    layout.tag(manifestADesc, Reference("r.example.com", "repo", "tag-a"))
-    layout.tag(manifestBDesc, Reference("r.example.com", "repo", "tag-b"))
+    layout.tag(ociManifestADesc, Reference("r.example.com", "repo", "tag-a"))
+    layout.tag(ociManifestBDesc, Reference("r.example.com", "repo", "tag-b"))
 
-    assertTrue(layout.remove(manifestADesc))
+    assertTrue(layout.remove(ociManifestADesc))
 
     assertNotNull(layout.fetchBlob(layerDesc) { it.readUtf8() })
     assertEquals(1, layout.catalog().size)
@@ -241,8 +241,8 @@ class LayoutTest {
       testJson
         .encodeToString(Manifest(config = configDesc, layers = listOf(layerDesc)))
         .toByteArray()
-    val manifestDesc = layout.writeBlob(manifestBytes, OciConstants.MANIFEST.mediaType)
-    layout.tag(manifestDesc, Reference("r.example.com", "repo", "v1"))
+    val ociManifestDesc = layout.writeBlob(manifestBytes, ManifestConstants.OCI.mediaType)
+    layout.tag(ociManifestDesc, Reference("r.example.com", "repo", "v1"))
 
     assertEquals(emptyList(), layout.gc())
     assertNotNull(layout.fetchBlob(layerDesc) { it.readUtf8() })

--- a/koci/src/test/kotlin/com/defenseunicorns/koci/LayoutTest.kt
+++ b/koci/src/test/kotlin/com/defenseunicorns/koci/LayoutTest.kt
@@ -39,7 +39,7 @@ class LayoutTest {
     val layout = buildLayout()
     repeat(3) { i ->
       val bytes = "content-$i".toByteArray()
-      val desc = layout.writeBlob(bytes, OciConstants.MANIFEST_MEDIA_TYPE)
+      val desc = layout.writeBlob(bytes, OciConstants.MANIFEST.mediaType)
       val ref = Reference("registry.example.com", "repo", "tag-$i")
       layout.tag(desc, ref)
     }
@@ -82,7 +82,7 @@ class LayoutTest {
   @Test
   fun `resolveDescriptor returns null when predicate never matches`() = runTest {
     val layout = buildLayout()
-    val desc = layout.writeBlob("x".toByteArray(), OciConstants.MANIFEST_MEDIA_TYPE)
+    val desc = layout.writeBlob("x".toByteArray(), OciConstants.MANIFEST.mediaType)
     layout.tag(desc, Reference("r.example.com", "repo", "v1"))
     assertNull(layout.resolveDescriptor { it.mediaType == "no/match" })
   }
@@ -90,8 +90,8 @@ class LayoutTest {
   @Test
   fun `resolveDescriptor returns first descriptor satisfying predicate`() = runTest {
     val layout = buildLayout()
-    val descA = layout.writeBlob("a".toByteArray(), OciConstants.MANIFEST_MEDIA_TYPE)
-    val descB = layout.writeBlob("b".toByteArray(), OciConstants.MANIFEST_MEDIA_TYPE)
+    val descA = layout.writeBlob("a".toByteArray(), OciConstants.MANIFEST.mediaType)
+    val descB = layout.writeBlob("b".toByteArray(), OciConstants.MANIFEST.mediaType)
     layout.tag(descA, Reference("r.example.com", "repo", "tag-a"))
     layout.tag(descB, Reference("r.example.com", "repo", "tag-b"))
     val found = layout.resolveDescriptor { it.digest == descA.digest }
@@ -109,7 +109,7 @@ class LayoutTest {
   @Test
   fun `resolveReference returns descriptor for its tagged reference`() = runTest {
     val layout = buildLayout()
-    val desc = layout.writeBlob("manifest".toByteArray(), OciConstants.MANIFEST_MEDIA_TYPE)
+    val desc = layout.writeBlob("manifest".toByteArray(), OciConstants.MANIFEST.mediaType)
     val ref = Reference("r.example.com", "repo", "latest")
     layout.tag(desc, ref)
     val resolved = layout.resolveReference(ref)
@@ -124,11 +124,11 @@ class LayoutTest {
     val arm64Bytes = "arm64-manifest".toByteArray()
     val amd64 =
       layout
-        .writeBlob(amd64Bytes, OciConstants.MANIFEST_MEDIA_TYPE)
+        .writeBlob(amd64Bytes, OciConstants.MANIFEST.mediaType)
         .copy(platform = Platform(architecture = "amd64", os = "linux"))
     val arm64 =
       layout
-        .writeBlob(arm64Bytes, OciConstants.MANIFEST_MEDIA_TYPE)
+        .writeBlob(arm64Bytes, OciConstants.MANIFEST.mediaType)
         .copy(platform = Platform(architecture = "arm64", os = "linux"))
     val ref = Reference("r.example.com", "repo", "latest")
     layout.tag(amd64, ref)
@@ -142,7 +142,7 @@ class LayoutTest {
   @Test
   fun `tag makes descriptor findable by reference`() = runTest {
     val layout = buildLayout()
-    val desc = layout.writeBlob("m".toByteArray(), OciConstants.MANIFEST_MEDIA_TYPE)
+    val desc = layout.writeBlob("m".toByteArray(), OciConstants.MANIFEST.mediaType)
     val ref = Reference("r.example.com", "repo", "v2")
     layout.tag(desc, ref)
     assertNotNull(layout.resolveReference(ref))
@@ -152,8 +152,8 @@ class LayoutTest {
   fun `tag replaces existing entry for the same reference`() = runTest {
     val layout = buildLayout()
     val ref = Reference("r.example.com", "repo", "stable")
-    val old = layout.writeBlob("old".toByteArray(), OciConstants.MANIFEST_MEDIA_TYPE)
-    val new = layout.writeBlob("new".toByteArray(), OciConstants.MANIFEST_MEDIA_TYPE)
+    val old = layout.writeBlob("old".toByteArray(), OciConstants.MANIFEST.mediaType)
+    val new = layout.writeBlob("new".toByteArray(), OciConstants.MANIFEST.mediaType)
     layout.tag(old, ref)
     layout.tag(new, ref)
     assertEquals(1, layout.catalog().size)
@@ -175,7 +175,7 @@ class LayoutTest {
       layout.writeBlob("{}".toByteArray(), "application/vnd.oci.image.config.v1+json")
     val manifestBytes =
       testJson.encodeToString(Manifest(config = configDesc, layers = emptyList())).toByteArray()
-    val manifestDesc = layout.writeBlob(manifestBytes, OciConstants.MANIFEST_MEDIA_TYPE)
+    val manifestDesc = layout.writeBlob(manifestBytes, OciConstants.MANIFEST.mediaType)
     val ref = Reference("r.example.com", "repo", "v1")
     layout.tag(manifestDesc, ref)
     layout.remove(ref)
@@ -202,8 +202,8 @@ class LayoutTest {
       testJson
         .encodeToString(Manifest(config = configBDesc, layers = listOf(layerDesc)))
         .toByteArray()
-    val manifestADesc = layout.writeBlob(manifestABytes, OciConstants.MANIFEST_MEDIA_TYPE)
-    val manifestBDesc = layout.writeBlob(manifestBBytes, OciConstants.MANIFEST_MEDIA_TYPE)
+    val manifestADesc = layout.writeBlob(manifestABytes, OciConstants.MANIFEST.mediaType)
+    val manifestBDesc = layout.writeBlob(manifestBBytes, OciConstants.MANIFEST.mediaType)
 
     layout.tag(manifestADesc, Reference("r.example.com", "repo", "tag-a"))
     layout.tag(manifestBDesc, Reference("r.example.com", "repo", "tag-b"))
@@ -241,7 +241,7 @@ class LayoutTest {
       testJson
         .encodeToString(Manifest(config = configDesc, layers = listOf(layerDesc)))
         .toByteArray()
-    val manifestDesc = layout.writeBlob(manifestBytes, OciConstants.MANIFEST_MEDIA_TYPE)
+    val manifestDesc = layout.writeBlob(manifestBytes, OciConstants.MANIFEST.mediaType)
     layout.tag(manifestDesc, Reference("r.example.com", "repo", "v1"))
 
     assertEquals(emptyList(), layout.gc())

--- a/koci/src/test/kotlin/com/defenseunicorns/koci/RepositoryTest.kt
+++ b/koci/src/test/kotlin/com/defenseunicorns/koci/RepositoryTest.kt
@@ -12,7 +12,7 @@ import com.defenseunicorns.koci.TestFixtures.testJson
 import com.defenseunicorns.koci.api.Descriptor
 import com.defenseunicorns.koci.api.Index
 import com.defenseunicorns.koci.api.Manifest
-import com.defenseunicorns.koci.api.OciConstants
+import com.defenseunicorns.koci.api.ManifestConstants
 import com.defenseunicorns.koci.api.Platform
 import com.defenseunicorns.koci.api.Reference
 import com.defenseunicorns.koci.api.TransferEvent
@@ -116,7 +116,7 @@ class RepositoryTest {
             status = HttpStatusCode.OK,
             headers =
               headersOf(
-                HttpHeaders.ContentType to listOf(OciConstants.MANIFEST.mediaType),
+                HttpHeaders.ContentType to listOf(ManifestConstants.OCI.mediaType),
                 "Docker-Content-Digest" to listOf(manifestDigest.toString()),
                 HttpHeaders.ContentLength to listOf(manifestBytes.size.toString()),
               ),
@@ -126,7 +126,7 @@ class RepositoryTest {
     val desc = repo.resolve("latest")
     assertNotNull(desc)
     assertEquals(manifestDigest, desc.digest)
-    assertEquals(OciConstants.MANIFEST.mediaType, desc.mediaType)
+    assertEquals(ManifestConstants.OCI.mediaType, desc.mediaType)
     assertEquals(manifestBytes.size.toLong(), desc.size)
   }
 
@@ -146,7 +146,7 @@ class RepositoryTest {
             status = HttpStatusCode.OK,
             headers =
               headersOf(
-                HttpHeaders.ContentType to listOf(OciConstants.DOCKER_MANIFEST.mediaType),
+                HttpHeaders.ContentType to listOf(ManifestConstants.DOCKER.mediaType),
                 "Docker-Content-Digest" to listOf(manifestDigest.toString()),
                 HttpHeaders.ContentLength to listOf(manifestBytes.size.toString()),
               ),
@@ -157,8 +157,8 @@ class RepositoryTest {
     val desc = repo.resolve("latest")
 
     assertNotNull(desc)
-    assertTrue(acceptHeaders?.contains(OciConstants.DOCKER_MANIFEST.mediaType) == true)
-    assertEquals(OciConstants.DOCKER_MANIFEST.mediaType, desc.mediaType)
+    assertTrue(acceptHeaders?.contains(ManifestConstants.DOCKER.mediaType) == true)
+    assertEquals(ManifestConstants.DOCKER.mediaType, desc.mediaType)
     assertEquals(manifestDigest, desc.digest)
     assertEquals(manifestBytes.size.toLong(), desc.size)
   }
@@ -173,7 +173,7 @@ class RepositoryTest {
             status = HttpStatusCode.OK,
             headers =
               headersOf(
-                HttpHeaders.ContentType to listOf(OciConstants.MANIFEST.mediaType),
+                HttpHeaders.ContentType to listOf(ManifestConstants.OCI.mediaType),
                 HttpHeaders.ContentLength to listOf("100"),
               ),
           )
@@ -188,7 +188,7 @@ class RepositoryTest {
       Index().apply {
         manifests.add(
           Descriptor(
-            mediaType = OciConstants.MANIFEST.mediaType,
+            mediaType = ManifestConstants.OCI.mediaType,
             digest = digestOf("amd64-manifest".toByteArray()),
             size = 100,
             platform = Platform(architecture = "amd64", os = "linux"),
@@ -196,7 +196,7 @@ class RepositoryTest {
         )
         manifests.add(
           Descriptor(
-            mediaType = OciConstants.MANIFEST.mediaType,
+            mediaType = ManifestConstants.OCI.mediaType,
             digest = digestOf("arm64-manifest".toByteArray()),
             size = 100,
             platform = Platform(architecture = "arm64", os = "linux"),
@@ -210,7 +210,7 @@ class RepositoryTest {
           respond(
             content = indexJson,
             status = HttpStatusCode.OK,
-            headers = headersOf(HttpHeaders.ContentType, OciConstants.INDEX.mediaType),
+            headers = headersOf(HttpHeaders.ContentType, ManifestConstants.INDEX.mediaType),
           )
         }
       )
@@ -225,7 +225,7 @@ class RepositoryTest {
       Index().apply {
         manifests.add(
           Descriptor(
-            mediaType = OciConstants.MANIFEST.mediaType,
+            mediaType = ManifestConstants.OCI.mediaType,
             digest = digestOf("amd64-manifest".toByteArray()),
             size = 100,
             platform = Platform(architecture = "amd64", os = "linux"),
@@ -239,7 +239,7 @@ class RepositoryTest {
           respond(
             content = indexJson,
             status = HttpStatusCode.OK,
-            headers = headersOf(HttpHeaders.ContentType, OciConstants.INDEX.mediaType),
+            headers = headersOf(HttpHeaders.ContentType, ManifestConstants.INDEX.mediaType),
           )
         }
       )
@@ -252,7 +252,7 @@ class RepositoryTest {
       Index().apply {
         manifests.add(
           Descriptor(
-            mediaType = OciConstants.MANIFEST.mediaType,
+            mediaType = ManifestConstants.OCI.mediaType,
             digest = digestOf("amd64-manifest".toByteArray()),
             size = 100,
             platform = Platform(architecture = "amd64", os = "linux"),
@@ -270,7 +270,7 @@ class RepositoryTest {
             status = HttpStatusCode.OK,
             headers =
               headersOf(
-                HttpHeaders.ContentType to listOf(OciConstants.INDEX.mediaType),
+                HttpHeaders.ContentType to listOf(ManifestConstants.INDEX.mediaType),
                 "Docker-Content-Digest" to listOf(indexDigest.toString()),
                 HttpHeaders.ContentLength to listOf(indexBytes.size.toString()),
               ),
@@ -279,7 +279,7 @@ class RepositoryTest {
       )
     val desc = repo.resolve("latest")
     assertNotNull(desc)
-    assertEquals(OciConstants.INDEX.mediaType, desc.mediaType)
+    assertEquals(ManifestConstants.INDEX.mediaType, desc.mediaType)
     assertEquals(indexDigest, desc.digest)
     assertEquals(indexBytes.size.toLong(), desc.size)
   }
@@ -331,7 +331,7 @@ class RepositoryTest {
                 status = HttpStatusCode.OK,
                 headers =
                   headersOf(
-                    HttpHeaders.ContentType to listOf(OciConstants.MANIFEST.mediaType),
+                    HttpHeaders.ContentType to listOf(ManifestConstants.OCI.mediaType),
                     "Docker-Content-Digest" to listOf(manifestDigest.toString()),
                     HttpHeaders.ContentLength to listOf(manifestBytes.size.toString()),
                   ),
@@ -341,7 +341,7 @@ class RepositoryTest {
               respond(
                 content = manifestBytes,
                 status = HttpStatusCode.OK,
-                headers = headersOf(HttpHeaders.ContentType, OciConstants.MANIFEST.mediaType),
+                headers = headersOf(HttpHeaders.ContentType, ManifestConstants.OCI.mediaType),
               )
 
             method == HttpMethod.Get && path.contains("/blobs/${configDesc.digest}") ->
@@ -402,7 +402,7 @@ class RepositoryTest {
     val bytes = content.toByteArray()
     val desc =
       Descriptor(
-        mediaType = OciConstants.DOCKER_MANIFEST.mediaType,
+        mediaType = ManifestConstants.DOCKER.mediaType,
         digest = digestOf(bytes),
         size = bytes.size.toLong(),
       )
@@ -416,7 +416,7 @@ class RepositoryTest {
           respond(
             content = bytes,
             status = HttpStatusCode.OK,
-            headers = headersOf(HttpHeaders.ContentType, OciConstants.DOCKER_MANIFEST.mediaType),
+            headers = headersOf(HttpHeaders.ContentType, ManifestConstants.DOCKER.mediaType),
           )
         }
       )
@@ -425,7 +425,7 @@ class RepositoryTest {
 
     assertEquals(content, result)
     assertTrue(requestPath?.contains("/manifests/${desc.digest}") == true)
-    assertTrue(acceptHeader?.contains(OciConstants.DOCKER_MANIFEST.mediaType) == true)
+    assertTrue(acceptHeader?.contains(ManifestConstants.DOCKER.mediaType) == true)
   }
 
   @Test
@@ -541,7 +541,7 @@ class RepositoryTest {
     val repo = fakeRepo(handler = { respond(content = "", status = HttpStatusCode.Created) })
     val result = repo.tag(manifest, "v1.0")
     assertNotNull(result)
-    assertEquals(OciConstants.MANIFEST.mediaType, result.mediaType)
+    assertEquals(ManifestConstants.OCI.mediaType, result.mediaType)
     assertNotNull(result.digest)
   }
 
@@ -590,7 +590,7 @@ class RepositoryTest {
     val repo = fakeRepo(handler = { respond(content = "", status = HttpStatusCode.Created) })
     val result = repo.tag(index, "latest")
     assertNotNull(result)
-    assertEquals(OciConstants.INDEX.mediaType, result.mediaType)
+    assertEquals(ManifestConstants.INDEX.mediaType, result.mediaType)
     assertNotNull(result.digest)
   }
 }

--- a/koci/src/test/kotlin/com/defenseunicorns/koci/RepositoryTest.kt
+++ b/koci/src/test/kotlin/com/defenseunicorns/koci/RepositoryTest.kt
@@ -116,7 +116,7 @@ class RepositoryTest {
             status = HttpStatusCode.OK,
             headers =
               headersOf(
-                HttpHeaders.ContentType to listOf(OciConstants.MANIFEST_MEDIA_TYPE),
+                HttpHeaders.ContentType to listOf(OciConstants.MANIFEST.mediaType),
                 "Docker-Content-Digest" to listOf(manifestDigest.toString()),
                 HttpHeaders.ContentLength to listOf(manifestBytes.size.toString()),
               ),
@@ -126,7 +126,40 @@ class RepositoryTest {
     val desc = repo.resolve("latest")
     assertNotNull(desc)
     assertEquals(manifestDigest, desc.digest)
-    assertEquals(OciConstants.MANIFEST_MEDIA_TYPE, desc.mediaType)
+    assertEquals(OciConstants.MANIFEST.mediaType, desc.mediaType)
+    assertEquals(manifestBytes.size.toLong(), desc.size)
+  }
+
+  @Test
+  fun `resolve supports Docker manifest media type`() = runTest {
+    val manifestBytes =
+      """{"schemaVersion":2,"config":{"mediaType":"application/vnd.docker.container.image.v1+json","digest":"sha256:${"b".repeat(64)}","size":1},"layers":[]}"""
+        .toByteArray()
+    val manifestDigest = digestOf(manifestBytes)
+    var acceptHeaders: List<String>? = null
+    val repo =
+      fakeRepo(
+        handler = { req ->
+          acceptHeaders = req.headers.getAll(HttpHeaders.Accept)
+          respond(
+            content = "",
+            status = HttpStatusCode.OK,
+            headers =
+              headersOf(
+                HttpHeaders.ContentType to listOf(OciConstants.DOCKER_MANIFEST.mediaType),
+                "Docker-Content-Digest" to listOf(manifestDigest.toString()),
+                HttpHeaders.ContentLength to listOf(manifestBytes.size.toString()),
+              ),
+          )
+        }
+      )
+
+    val desc = repo.resolve("latest")
+
+    assertNotNull(desc)
+    assertTrue(acceptHeaders?.contains(OciConstants.DOCKER_MANIFEST.mediaType) == true)
+    assertEquals(OciConstants.DOCKER_MANIFEST.mediaType, desc.mediaType)
+    assertEquals(manifestDigest, desc.digest)
     assertEquals(manifestBytes.size.toLong(), desc.size)
   }
 
@@ -140,7 +173,7 @@ class RepositoryTest {
             status = HttpStatusCode.OK,
             headers =
               headersOf(
-                HttpHeaders.ContentType to listOf(OciConstants.MANIFEST_MEDIA_TYPE),
+                HttpHeaders.ContentType to listOf(OciConstants.MANIFEST.mediaType),
                 HttpHeaders.ContentLength to listOf("100"),
               ),
           )
@@ -155,7 +188,7 @@ class RepositoryTest {
       Index().apply {
         manifests.add(
           Descriptor(
-            mediaType = OciConstants.MANIFEST_MEDIA_TYPE,
+            mediaType = OciConstants.MANIFEST.mediaType,
             digest = digestOf("amd64-manifest".toByteArray()),
             size = 100,
             platform = Platform(architecture = "amd64", os = "linux"),
@@ -163,7 +196,7 @@ class RepositoryTest {
         )
         manifests.add(
           Descriptor(
-            mediaType = OciConstants.MANIFEST_MEDIA_TYPE,
+            mediaType = OciConstants.MANIFEST.mediaType,
             digest = digestOf("arm64-manifest".toByteArray()),
             size = 100,
             platform = Platform(architecture = "arm64", os = "linux"),
@@ -177,7 +210,7 @@ class RepositoryTest {
           respond(
             content = indexJson,
             status = HttpStatusCode.OK,
-            headers = headersOf(HttpHeaders.ContentType, OciConstants.INDEX_MEDIA_TYPE),
+            headers = headersOf(HttpHeaders.ContentType, OciConstants.INDEX.mediaType),
           )
         }
       )
@@ -192,7 +225,7 @@ class RepositoryTest {
       Index().apply {
         manifests.add(
           Descriptor(
-            mediaType = OciConstants.MANIFEST_MEDIA_TYPE,
+            mediaType = OciConstants.MANIFEST.mediaType,
             digest = digestOf("amd64-manifest".toByteArray()),
             size = 100,
             platform = Platform(architecture = "amd64", os = "linux"),
@@ -206,7 +239,7 @@ class RepositoryTest {
           respond(
             content = indexJson,
             status = HttpStatusCode.OK,
-            headers = headersOf(HttpHeaders.ContentType, OciConstants.INDEX_MEDIA_TYPE),
+            headers = headersOf(HttpHeaders.ContentType, OciConstants.INDEX.mediaType),
           )
         }
       )
@@ -219,7 +252,7 @@ class RepositoryTest {
       Index().apply {
         manifests.add(
           Descriptor(
-            mediaType = OciConstants.MANIFEST_MEDIA_TYPE,
+            mediaType = OciConstants.MANIFEST.mediaType,
             digest = digestOf("amd64-manifest".toByteArray()),
             size = 100,
             platform = Platform(architecture = "amd64", os = "linux"),
@@ -237,7 +270,7 @@ class RepositoryTest {
             status = HttpStatusCode.OK,
             headers =
               headersOf(
-                HttpHeaders.ContentType to listOf(OciConstants.INDEX_MEDIA_TYPE),
+                HttpHeaders.ContentType to listOf(OciConstants.INDEX.mediaType),
                 "Docker-Content-Digest" to listOf(indexDigest.toString()),
                 HttpHeaders.ContentLength to listOf(indexBytes.size.toString()),
               ),
@@ -246,7 +279,7 @@ class RepositoryTest {
       )
     val desc = repo.resolve("latest")
     assertNotNull(desc)
-    assertEquals(OciConstants.INDEX_MEDIA_TYPE, desc.mediaType)
+    assertEquals(OciConstants.INDEX.mediaType, desc.mediaType)
     assertEquals(indexDigest, desc.digest)
     assertEquals(indexBytes.size.toLong(), desc.size)
   }
@@ -298,7 +331,7 @@ class RepositoryTest {
                 status = HttpStatusCode.OK,
                 headers =
                   headersOf(
-                    HttpHeaders.ContentType to listOf(OciConstants.MANIFEST_MEDIA_TYPE),
+                    HttpHeaders.ContentType to listOf(OciConstants.MANIFEST.mediaType),
                     "Docker-Content-Digest" to listOf(manifestDigest.toString()),
                     HttpHeaders.ContentLength to listOf(manifestBytes.size.toString()),
                   ),
@@ -308,7 +341,7 @@ class RepositoryTest {
               respond(
                 content = manifestBytes,
                 status = HttpStatusCode.OK,
-                headers = headersOf(HttpHeaders.ContentType, OciConstants.MANIFEST_MEDIA_TYPE),
+                headers = headersOf(HttpHeaders.ContentType, OciConstants.MANIFEST.mediaType),
               )
 
             method == HttpMethod.Get && path.contains("/blobs/${configDesc.digest}") ->
@@ -361,6 +394,38 @@ class RepositoryTest {
       )
     val result = repo.fetch(desc) { stream -> stream.readBytes().toString(Charsets.UTF_8) }
     assertEquals(content, result)
+  }
+
+  @Test
+  fun `fetch routes Docker manifest descriptors through manifest endpoint`() = runTest {
+    val content = "docker manifest"
+    val bytes = content.toByteArray()
+    val desc =
+      Descriptor(
+        mediaType = OciConstants.DOCKER_MANIFEST.mediaType,
+        digest = digestOf(bytes),
+        size = bytes.size.toLong(),
+      )
+    var requestPath: String? = null
+    var acceptHeader: String? = null
+    val repo =
+      fakeRepo(
+        handler = { req ->
+          requestPath = req.url.encodedPath
+          acceptHeader = req.headers[HttpHeaders.Accept]
+          respond(
+            content = bytes,
+            status = HttpStatusCode.OK,
+            headers = headersOf(HttpHeaders.ContentType, OciConstants.DOCKER_MANIFEST.mediaType),
+          )
+        }
+      )
+
+    val result = repo.fetch(desc) { stream -> stream.readBytes().toString(Charsets.UTF_8) }
+
+    assertEquals(content, result)
+    assertTrue(requestPath?.contains("/manifests/${desc.digest}") == true)
+    assertTrue(acceptHeader?.contains(OciConstants.DOCKER_MANIFEST.mediaType) == true)
   }
 
   @Test
@@ -476,7 +541,7 @@ class RepositoryTest {
     val repo = fakeRepo(handler = { respond(content = "", status = HttpStatusCode.Created) })
     val result = repo.tag(manifest, "v1.0")
     assertNotNull(result)
-    assertEquals(OciConstants.MANIFEST_MEDIA_TYPE, result.mediaType)
+    assertEquals(OciConstants.MANIFEST.mediaType, result.mediaType)
     assertNotNull(result.digest)
   }
 
@@ -525,7 +590,7 @@ class RepositoryTest {
     val repo = fakeRepo(handler = { respond(content = "", status = HttpStatusCode.Created) })
     val result = repo.tag(index, "latest")
     assertNotNull(result)
-    assertEquals(OciConstants.INDEX_MEDIA_TYPE, result.mediaType)
+    assertEquals(OciConstants.INDEX.mediaType, result.mediaType)
     assertNotNull(result.digest)
   }
 }

--- a/koci/src/test/kotlin/com/defenseunicorns/koci/RouteTest.kt
+++ b/koci/src/test/kotlin/com/defenseunicorns/koci/RouteTest.kt
@@ -8,7 +8,7 @@ package com.defenseunicorns.koci
 import com.defenseunicorns.koci.api.ANNOTATION_TITLE
 import com.defenseunicorns.koci.api.Descriptor
 import com.defenseunicorns.koci.api.Digest
-import com.defenseunicorns.koci.api.OciConstants
+import com.defenseunicorns.koci.api.ManifestConstants
 import com.defenseunicorns.koci.internal.Router
 import io.ktor.http.URLBuilder
 import kotlin.test.Test
@@ -68,7 +68,7 @@ class RouteTest {
 
     val desc =
       Descriptor(
-        mediaType = OciConstants.MANIFEST.mediaType,
+        mediaType = ManifestConstants.OCI.mediaType,
         digest = digest("sha256:12120425f07de11a1b899e418d4b0ea174c8d4d572d45bdb640f93bc7ca06a3d"),
         size = 0, // dummy size
       )

--- a/koci/src/test/kotlin/com/defenseunicorns/koci/RouteTest.kt
+++ b/koci/src/test/kotlin/com/defenseunicorns/koci/RouteTest.kt
@@ -8,7 +8,7 @@ package com.defenseunicorns.koci
 import com.defenseunicorns.koci.api.ANNOTATION_TITLE
 import com.defenseunicorns.koci.api.Descriptor
 import com.defenseunicorns.koci.api.Digest
-import com.defenseunicorns.koci.api.OciConstants.MANIFEST_MEDIA_TYPE
+import com.defenseunicorns.koci.api.OciConstants
 import com.defenseunicorns.koci.internal.Router
 import io.ktor.http.URLBuilder
 import kotlin.test.Test
@@ -68,7 +68,7 @@ class RouteTest {
 
     val desc =
       Descriptor(
-        mediaType = MANIFEST_MEDIA_TYPE.toString(),
+        mediaType = OciConstants.MANIFEST.mediaType,
         digest = digest("sha256:12120425f07de11a1b899e418d4b0ea174c8d4d572d45bdb640f93bc7ca06a3d"),
         size = 0, // dummy size
       )

--- a/koci/src/test/kotlin/com/defenseunicorns/koci/TestFixtures.kt
+++ b/koci/src/test/kotlin/com/defenseunicorns/koci/TestFixtures.kt
@@ -8,7 +8,7 @@ package com.defenseunicorns.koci
 import com.defenseunicorns.koci.api.Descriptor
 import com.defenseunicorns.koci.api.Digest
 import com.defenseunicorns.koci.api.Layout
-import com.defenseunicorns.koci.api.OciConstants
+import com.defenseunicorns.koci.api.ManifestConstants
 import com.defenseunicorns.koci.api.RegisteredAlgorithm
 import com.defenseunicorns.koci.api.Registry
 import com.defenseunicorns.koci.api.config.PullConfig
@@ -71,9 +71,9 @@ object TestFixtures {
         engine { addHandler(handler) }
         install(ContentNegotiation) {
           json(testJson)
-          json(testJson, contentType = ContentType.parse(OciConstants.INDEX.mediaType))
-          json(testJson, contentType = ContentType.parse(OciConstants.MANIFEST.mediaType))
-          json(testJson, contentType = ContentType.parse(OciConstants.DOCKER_MANIFEST.mediaType))
+          json(testJson, contentType = ContentType.parse(ManifestConstants.INDEX.mediaType))
+          json(testJson, contentType = ContentType.parse(ManifestConstants.OCI.mediaType))
+          json(testJson, contentType = ContentType.parse(ManifestConstants.DOCKER.mediaType))
         }
       }
     return Registry(

--- a/koci/src/test/kotlin/com/defenseunicorns/koci/TestFixtures.kt
+++ b/koci/src/test/kotlin/com/defenseunicorns/koci/TestFixtures.kt
@@ -71,8 +71,9 @@ object TestFixtures {
         engine { addHandler(handler) }
         install(ContentNegotiation) {
           json(testJson)
-          json(testJson, contentType = ContentType.parse(OciConstants.INDEX_MEDIA_TYPE))
-          json(testJson, contentType = ContentType.parse(OciConstants.MANIFEST_MEDIA_TYPE))
+          json(testJson, contentType = ContentType.parse(OciConstants.INDEX.mediaType))
+          json(testJson, contentType = ContentType.parse(OciConstants.MANIFEST.mediaType))
+          json(testJson, contentType = ContentType.parse(OciConstants.DOCKER_MANIFEST.mediaType))
         }
       }
     return Registry(


### PR DESCRIPTION
We now support `application/vnd.docker.distribution.manifest.v2+json` manifests. Added tests.

Note: this breaks the public API since we switched to an enum for OciConstants so we can iterate over them
