### PR TITLE
fix: logging http calls

### DIFF
--- a/koci/src/main/kotlin/com/defenseunicorns/koci/api/Registry.kt
+++ b/koci/src/main/kotlin/com/defenseunicorns/koci/api/Registry.kt
@@ -14,6 +14,7 @@ import com.defenseunicorns.koci.internal.Regex.linkRegex
 import com.defenseunicorns.koci.internal.Router
 import com.defenseunicorns.koci.internal.SCOPE_REGISTRY_CATALOG
 import com.defenseunicorns.koci.internal.appendScopes
+import com.defenseunicorns.koci.internal.summary
 import io.ktor.client.call.body
 import io.ktor.client.request.url
 import io.ktor.http.HttpHeaders
@@ -68,6 +69,10 @@ internal constructor(
         operation = "registry.ping",
         buildRequest = { url(router.base()) },
         onSuccess = { true },
+        onError = { failure ->
+          logger.error { "registry ping failed for $url: ${failure.summary()}" }
+          false
+        },
       )
     return outcome ?: false
   }
@@ -102,6 +107,12 @@ internal constructor(
             val next = parseNextLink(res.headers[HttpHeaders.Link])
             val repos = res.body<CatalogResponse>().repositories.map { repo(it) }
             repos to next
+          },
+          onError = { failure ->
+            logger.error {
+              "registry catalog page could not be listed from $pageUrl: ${failure.summary()}"
+            }
+            null
           },
         )
 

--- a/koci/src/main/kotlin/com/defenseunicorns/koci/internal/FailureResponse.kt
+++ b/koci/src/main/kotlin/com/defenseunicorns/koci/internal/FailureResponse.kt
@@ -20,3 +20,17 @@ internal data class FailureResponse(
   val status: HttpStatusCode,
   val errors: List<ActionableFailure>,
 )
+
+internal fun FailureResponse.summary(): String {
+  val detail =
+    errors
+      .joinToString(separator = "; ") { failure ->
+        when (failure.message.isBlank()) {
+          true -> failure.code.name
+          false -> "${failure.code.name}: ${failure.message}"
+        }
+      }
+      .ifBlank { ErrorCode.UNKNOWN.name }
+
+  return "HTTP ${status.value} ${status.description} ($detail)"
+}

--- a/koci/src/main/kotlin/com/defenseunicorns/koci/internal/HttpWrapper.kt
+++ b/koci/src/main/kotlin/com/defenseunicorns/koci/internal/HttpWrapper.kt
@@ -20,8 +20,8 @@ import kotlinx.serialization.Serializable
  * Single entry point for every HTTP request koci makes against an upstream registry. Engine
  * exceptions (transport failure, timeout, engine closed, deserialization throws) become `null`.
  * Status branching happens once: 2xx goes to [onSuccess], everything else is parsed into a
- * [FailureResponse] and handed to [onError], which defaults to logging and returning `null`.
- * [CancellationException] is rethrown so coroutine cancellation propagates.
+ * [FailureResponse] and handed to [onError]. [CancellationException] is rethrown so coroutine
+ * cancellation propagates.
  */
 internal class HttpWrapper(private val client: HttpClient, private val logger: KociLogger) {
 
@@ -34,10 +34,7 @@ internal class HttpWrapper(private val client: HttpClient, private val logger: K
   suspend fun <T> call(
     operation: String,
     buildRequest: HttpRequestBuilder.() -> Unit,
-    onError: suspend (FailureResponse) -> T? = {
-      logger.warn { "[$operation] call failed: $it" }
-      null
-    },
+    onError: suspend (FailureResponse) -> T?,
     onSuccess: suspend (HttpResponse) -> T?,
   ): T? =
     try {

--- a/koci/src/main/kotlin/com/defenseunicorns/koci/internal/RealKociLogger.kt
+++ b/koci/src/main/kotlin/com/defenseunicorns/koci/internal/RealKociLogger.kt
@@ -7,7 +7,7 @@ package com.defenseunicorns.koci.internal
 
 import co.touchlab.kermit.Logger
 import co.touchlab.kermit.Severity
-import co.touchlab.kermit.loggerConfigInit
+import co.touchlab.kermit.StaticConfig
 import com.defenseunicorns.koci.api.LogLevel
 
 internal interface KociLogger {
@@ -24,7 +24,7 @@ internal class RealKociLogger(logLevel: LogLevel) : KociLogger {
   private val log =
     Logger(
       config =
-        loggerConfigInit(
+        StaticConfig(
           minSeverity =
             when (logLevel) {
               LogLevel.Debug -> Severity.Debug
@@ -40,7 +40,7 @@ internal class RealKociLogger(logLevel: LogLevel) : KociLogger {
 
   override fun info(message: () -> String) = log.i { message() }
 
-  override fun warn(message: () -> String) = log.a { message() }
+  override fun warn(message: () -> String) = log.w { message() }
 
   override fun error(throwable: Throwable?, message: () -> String) = log.e(throwable) { message() }
 }

--- a/koci/src/main/kotlin/com/defenseunicorns/koci/internal/RepositoryPuller.kt
+++ b/koci/src/main/kotlin/com/defenseunicorns/koci/internal/RepositoryPuller.kt
@@ -91,6 +91,10 @@ internal class RepositoryPuller(
         attributes.appendScopes(scopeRepository(name, ACTION_PULL))
       },
       onSuccess = { res -> res.body<TagsResponse>().tags },
+      onError = { failure ->
+        logger.error { "repository tags could not be listed for $name: ${failure.summary()}" }
+        null
+      },
     ) ?: emptyList()
 
   /**
@@ -130,6 +134,10 @@ internal class RepositoryPuller(
             null
           }
         }
+      },
+      onError = { failure ->
+        logger.error { "manifest '$tag' could not be resolved in $name: ${failure.summary()}" }
+        null
       },
     )
   }
@@ -367,6 +375,10 @@ internal class RepositoryPuller(
           attributes.appendScopes(scopeRepository(name, ACTION_PULL))
         },
         onSuccess = { res -> res.headers["Accept-Ranges"] == "bytes" },
+        onError = { failure ->
+          logger.error { "range support probe failed for $name: ${failure.summary()}" }
+          null
+        },
       ) ?: false
     rangeSupported = result
     return result
@@ -406,7 +418,12 @@ internal class RepositoryPuller(
     operation: String,
     method: HttpMethod = HttpMethod.Get,
     extraBuild: HttpRequestBuilder.() -> Unit = {},
-    onError: suspend (FailureResponse) -> T? = { null },
+    onError: suspend (FailureResponse) -> T? = { failure ->
+      logger.error {
+        "$operation failed for $name descriptor ${descriptor.digest}: ${failure.summary()}"
+      }
+      null
+    },
     onSuccess: suspend (HttpResponse) -> T?,
   ): T? {
     val endpoint = endpointFor(descriptor) ?: return null

--- a/koci/src/main/kotlin/com/defenseunicorns/koci/internal/RepositoryPusher.kt
+++ b/koci/src/main/kotlin/com/defenseunicorns/koci/internal/RepositoryPusher.kt
@@ -274,6 +274,10 @@ internal class RepositoryPusher(
           attributes.appendScopes(scopeRepository(name, ACTION_PULL, ACTION_PUSH))
         },
         onSuccess = { res -> res.status },
+        onError = { failure ->
+          logger.error { "manifest '$ref' could not be pushed to $name: ${failure.summary()}" }
+          failure.status
+        },
       )
     return status == HttpStatusCode.Created
   }
@@ -320,6 +324,12 @@ internal class RepositoryPusher(
           attributes.appendScopes(scopeRepository(name, ACTION_PULL, ACTION_PUSH))
         },
         onSuccess = { res -> res.status },
+        onError = { failure ->
+          logger.error {
+            "monolithic blob upload could not be committed for ${expected.digest}: ${failure.summary()}"
+          }
+          failure.status
+        },
       )
     return status == HttpStatusCode.Created
   }
@@ -351,7 +361,8 @@ internal class RepositoryPusher(
         val want = minOf(expected.size - offset, chunkSize)
         if (want <= 0L) break
 
-        val updated = pushChunk(currentLocation, source, want, offset) ?: return@withContext false
+        val updated =
+          pushChunk(currentLocation, source, want, offset, expected) ?: return@withContext false
         currentLocation = updated.location
         uploading[expected] = updated.copy(minChunkSize = chunkSize)
         offset = updated.offset + 1
@@ -371,6 +382,7 @@ internal class RepositoryPusher(
     source: BufferedSource,
     chunkSize: Long,
     offset: Long,
+    expected: Descriptor,
   ): UploadStatus? {
     val endRange = offset + chunkSize - 1
     return caller.call(
@@ -395,6 +407,12 @@ internal class RepositoryPusher(
           }
         }
       },
+      onError = { failure ->
+        logger.error {
+          "blob chunk could not be pushed for ${expected.digest}: ${failure.summary()}"
+        }
+        null
+      },
     )
   }
 
@@ -413,8 +431,10 @@ internal class RepositoryPusher(
           attributes.appendScopes(scopeRepository(name, ACTION_PULL, ACTION_PUSH))
         },
         onSuccess = { res -> res.status },
-        onError = {
-          logger.warn { "commit upload failed: $it" }
+        onError = { failure ->
+          logger.error {
+            "chunked blob upload could not be committed for ${expected.digest}: ${failure.summary()}"
+          }
           null
         },
       )
@@ -448,6 +468,12 @@ internal class RepositoryPusher(
               else -> null
             }
           },
+          onError = { failure ->
+            logger.error {
+              "blob upload session could not be started for ${descriptor.digest}: ${failure.summary()}"
+            }
+            null
+          },
         )
 
     if (prev.offset > 0) {
@@ -458,7 +484,12 @@ internal class RepositoryPusher(
             url(router.parseUploadLocation(prev.location))
             attributes.appendScopes(scopeRepository(name, ACTION_PULL))
           },
-          onError = { failure -> failure.status to null },
+          onError = { failure ->
+            logger.error {
+              "blob upload session status could not be refreshed for ${descriptor.digest}: ${failure.summary()}"
+            }
+            failure.status to null
+          },
           onSuccess = { res -> res.status to res.headers.toUploadStatus() },
         )
       val resume = outcome ?: return null

--- a/koci/src/test/kotlin/com/defenseunicorns/koci/HttpWrapperTest.kt
+++ b/koci/src/test/kotlin/com/defenseunicorns/koci/HttpWrapperTest.kt
@@ -42,6 +42,7 @@ class HttpWrapperTest {
         w.call(
           operation = "op",
           buildRequest = { url("https://test/") },
+          onError = { error("should not run") },
           onSuccess = { res -> res.bodyAsText() },
         )
       assertEquals("hello", outcome)
@@ -112,12 +113,13 @@ class HttpWrapperTest {
   }
 
   @Test
-  fun `default onError returns null for non-2xx responses`() = runTest {
+  fun `onError can return null for non-2xx responses`() = runTest {
     withWrapper({ respondError(HttpStatusCode.InternalServerError) }) { w ->
       val outcome =
         w.call(
           operation = "op",
           buildRequest = { url("https://test/") },
+          onError = { null },
           onSuccess = { res -> res.bodyAsText() },
         )
       assertEquals(null, outcome)
@@ -133,6 +135,7 @@ class HttpWrapperTest {
         w.call(
           operation = "op",
           buildRequest = { url("https://test/") },
+          onError = { error("should not run") },
           onSuccess = { res -> Pair(res.headers[HttpHeaders.ContentType], res.bodyAsText()) },
         )
       assertIs<Pair<String?, String>>(outcome)
@@ -159,6 +162,7 @@ class HttpWrapperTest {
           url("https://example.com/path")
           headers.append("X-Test", "value")
         },
+        onError = { error("should not run") },
         onSuccess = { res -> res.status.value },
       )
     }
@@ -175,6 +179,7 @@ class HttpWrapperTest {
         w.call(
           operation = "op",
           buildRequest = { url("https://test/") },
+          onError = { error("should not run") },
           onSuccess = { it.bodyAsText() },
         )
       assertEquals(null, outcome)
@@ -188,6 +193,7 @@ class HttpWrapperTest {
         w.call<Unit>(
           operation = "op",
           buildRequest = { url("https://test/") },
+          onError = { error("should not run") },
           onSuccess = { _ -> error("decode blew up") },
         )
       assertEquals(null, outcome)
@@ -221,6 +227,7 @@ class HttpWrapperTest {
         w.call(
           operation = "op",
           buildRequest = { url("https://test/") },
+          onError = { error("should not run") },
           onSuccess = { it.bodyAsText() },
         )
       assertEquals(null, outcome)


### PR DESCRIPTION
There was a default parameter bug with `onError` for http calls. If we did not pass in a lambda for `onError`, it would default to `{ null }` and not log anything. We removed the default paramemter, so now call sites need to supply an `onError`.

There was also another bug with the `kermit` logger implementation. We did not pass in any `writers` so logs were happening, but since there were no writers, nothing was being output. Now we use a `StaticCongi` which defaults to `CommonWriter` which works.
