### PR TITLE
chore: dependabot ignores koci and now use library toml

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -7,6 +7,8 @@ updates:
     commit-message:
       include: scope
       prefix: build
+    ignore:
+      - dependency-name: "com.defenseunicorns:koci"
     groups:
       gradle:
         patterns:

--- a/bench/current/build.gradle.kts
+++ b/bench/current/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
-  kotlin("jvm") version "2.2.10"
-  kotlin("plugin.serialization") version "2.2.10"
+  alias(libs.plugins.jetbrains.kotlin.jvm)
+  alias(libs.plugins.kotlin.serialization)
 }
 
 kotlin { jvmToolchain(21) }
@@ -8,9 +8,9 @@ kotlin { jvmToolchain(21) }
 dependencies {
   implementation(project(":bench:harness"))
   implementation(project(":koci"))
-  implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2")
-  implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.9.0")
-  implementation("org.slf4j:slf4j-nop:2.0.16")
+  implementation(libs.kotlinx.coroutines.core)
+  implementation(libs.kotlinx.serialization.json)
+  implementation(libs.slf4j.nop)
 }
 
 tasks.register<JavaExec>("bench") {

--- a/bench/harness/build.gradle.kts
+++ b/bench/harness/build.gradle.kts
@@ -1,10 +1,10 @@
 plugins {
-  kotlin("jvm") version "2.2.10"
-  kotlin("plugin.serialization") version "2.2.10"
+  alias(libs.plugins.jetbrains.kotlin.jvm)
+  alias(libs.plugins.kotlin.serialization)
 }
 
 kotlin { jvmToolchain(21) }
 
 dependencies {
-  implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.9.0")
+  implementation(libs.kotlinx.serialization.json)
 }

--- a/bench/v1/build.gradle.kts
+++ b/bench/v1/build.gradle.kts
@@ -1,18 +1,18 @@
 plugins {
-  kotlin("jvm") version "2.2.10"
-  kotlin("plugin.serialization") version "2.2.10"
+  alias(libs.plugins.jetbrains.kotlin.jvm)
+  alias(libs.plugins.kotlin.serialization)
 }
 
 kotlin { jvmToolchain(21) }
 
 dependencies {
   implementation(project(":bench:harness"))
-  implementation("com.defenseunicorns:koci:0.4.3")
-  implementation("io.ktor:ktor-client-core:3.2.3")
-  implementation("io.ktor:ktor-client-cio:3.2.3")
-  implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2")
-  implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.9.0")
-  implementation("org.slf4j:slf4j-nop:2.0.16")
+  implementation(libs.koci)
+  implementation(libs.ktor.client.core)
+  implementation(libs.ktor.client.cio)
+  implementation(libs.kotlinx.coroutines.core)
+  implementation(libs.kotlinx.serialization.json)
+  implementation(libs.slf4j.nop)
 }
 
 tasks.register<JavaExec>("bench") {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,19 +6,23 @@ kotlinxCoroutinesTest = "1.10.2"
 kotlinxSerializationJson = "1.9.0"
 ktorClient = "3.2.3"
 kover = "0.9.1"
+koci = "0.4.3"
 detekt = "2.0.0-alpha.1"
 mavenPublish = "0.34.0"
 spotless = "8.0.0"
 binary-validator = "0.18.1"
 okio = "3.16.2"
 kermit = "2.0.4"
+slf4jNop = "2.0.16"
 
 [libraries]
 detekt-library-rules = { module = "dev.detekt:detekt-rules-libraries", version.ref = "detekt" }
 detekt-gradle-plugin = { module = "dev.detekt:detekt-gradle-plugin", version.ref = "detekt" }
 spotless-gradle-plugin = { module = "com.diffplug.spotless:spotless-plugin-gradle", version.ref = "spotless" }
 maven-publish-gradle-plugin = { module = "com.vanniktech:gradle-maven-publish-plugin", version.ref = "mavenPublish" }
+koci = { module = "com.defenseunicorns:koci", version.ref = "koci" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
+kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinxCoroutinesCore" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinxCoroutinesTest" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
@@ -31,6 +35,7 @@ ktor-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation",
 okio = { module = "com.squareup.okio:okio", version.ref = "okio" }
 okio-fakefilesystem = { module = "com.squareup.okio:okio-fakefilesystem", version.ref = "okio" }
 kermit = { module = "co.touchlab:kermit", version.ref = "kermit"}
+slf4j-nop = { module = "org.slf4j:slf4j-nop", version.ref = "slf4jNop" }
 
 [plugins]
 detekt = { id = "dev.detekt", version.ref = "detekt" }

--- a/koci/build.gradle.kts
+++ b/koci/build.gradle.kts
@@ -34,7 +34,7 @@ dependencies {
   testImplementation(libs.kotlinx.coroutines.test)
   testImplementation(libs.ktor.client.mock)
   testImplementation(libs.okio.fakefilesystem)
-  testImplementation(kotlin("test"))
+  testImplementation(libs.kotlin.test)
 }
 
 tasks.test {


### PR DESCRIPTION
Dependabot was trying to update koci, but it is purposefully older so we can test against the latest and oras. Also moves deps to fully use the versions toml.
